### PR TITLE
hp search wrapper, misc open files, extend ADI capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ATOM Modeling PipeLine (AMPL) for Drug Discovery
-[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/ATOMconsortium/AMPL/blob/master/LICENSE)
+[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/ATOMScience-org/AMPL/blob/master/LICENSE)
 
 *Created by the [Accelerating Therapeutics for Opportunites in Medicine (ATOM) Consortium](https://atomscience.org)*
 
@@ -63,7 +63,7 @@ AMPL is a Python 3 package that has been developed and run in a specific conda e
 ### Install
 #### Clone the git repository
 
-`git clone https://github.com/ATOMconsortium/AMPL.git`  
+`git clone https://github.com/ATOMScience-org/AMPL.git`  
 &nbsp;  
 
 #### Create conda environment
@@ -134,7 +134,7 @@ python -m ipykernel install --user --name atomsci
 ---
 <a name="AMPL-tutorials"></a>
 ## AMPL tutorials
- Please follow the link, [`atomsci/ddm/examples/tutorials`](https://github.com/ATOMconsortium/AMPL/tree/master/atomsci/ddm/examples/tutorials), to access a collection of AMPL tutorial COLAB (Jupyter) notebooks. The tutorial notebooks give an exhaustive coverage of AMPL features. The AMPL team has prepared the tutorials to help beginners understand the basics to advanced AMPL features, and a reference for advanced AMPL users. 
+ Please follow the link, [`atomsci/ddm/examples/tutorials`](https://github.com/ATOMScience-org/AMPL/tree/master/atomsci/ddm/examples/tutorials), to access a collection of AMPL tutorial COLAB (Jupyter) notebooks. The tutorial notebooks give an exhaustive coverage of AMPL features. The AMPL team has prepared the tutorials to help beginners understand the basics to advanced AMPL features, and a reference for advanced AMPL users. 
 &nbsp;  
 &nbsp;  
 

--- a/atomsci/ddm/pipeline/model_datasets.py
+++ b/atomsci/ddm/pipeline/model_datasets.py
@@ -578,8 +578,8 @@ class ModelDataset(object):
             for f in range(self.splitting.num_folds):
                 train_df = train_valid_df[train_valid_df.fold != f]
                 valid_df = train_valid_df[train_valid_df.fold == f]
-                train_dset = split.select_dset_by_id_list(self.dataset, train_df.cmpd_id.values)
-                valid_dset = split.select_dset_by_id_list(self.dataset, valid_df.cmpd_id.values)
+                train_dset = split.select_dset_by_id_list(self.dataset, train_df.cmpd_id.astype(str).values)
+                valid_dset = split.select_dset_by_id_list(self.dataset, valid_df.cmpd_id.astype(str).values)
                 train_attr = split.select_attrs_by_dset_ids(train_dset, self.attr)
                 valid_attr = split.select_attrs_by_dset_ids(valid_dset, self.attr)
                 self.train_valid_dsets.append((train_dset, valid_dset))
@@ -587,15 +587,15 @@ class ModelDataset(object):
         else:
             train_df = split_df[split_df.subset == 'train']
             valid_df = split_df[split_df.subset == 'valid']
-            train_dset = split.select_dset_by_id_list(self.dataset, train_df.cmpd_id.values)
-            valid_dset = split.select_dset_by_id_list(self.dataset, valid_df.cmpd_id.values)
+            train_dset = split.select_dset_by_id_list(self.dataset, train_df.cmpd_id.astype(str).values)
+            valid_dset = split.select_dset_by_id_list(self.dataset, valid_df.cmpd_id.astype(str).values)
             train_attr = split.select_attrs_by_dset_ids(train_dset, self.attr)
             valid_attr = split.select_attrs_by_dset_ids(valid_dset, self.attr)
             self.train_valid_dsets.append((train_dset, valid_dset))
             self.train_valid_attr.append((train_attr, valid_attr))
 
         test_df = split_df[split_df.subset == 'test']
-        self.test_dset = split.select_dset_by_id_list(self.dataset, test_df.cmpd_id.values)
+        self.test_dset = split.select_dset_by_id_list(self.dataset, test_df.cmpd_id.astype(str).values)
         self.test_attr = split.select_attrs_by_dset_ids(self.test_dset, self.attr)
 
         self.log.warning('Previous dataset split restored')

--- a/atomsci/ddm/pipeline/model_wrapper.py
+++ b/atomsci/ddm/pipeline/model_wrapper.py
@@ -255,7 +255,9 @@ class ModelWrapper(object):
 
             # Transformers are no longer saved as separate datastore objects; they are included in the model tarball
             self.params.transformer_key = os.path.join(self.output_dir, 'transformers.pkl')
-            pickle.dump((self.transformers, self.transformers_x), open(self.params.transformer_key, 'wb'))
+            txfmrpkl=open(self.params.transformer_key, 'wb')
+            pickle.dump((self.transformers, self.transformers_x), txfmrpkl)
+            txfmrpkl.close()
             self.log.info("Wrote transformers to %s" % self.params.transformer_key)
             self.params.transformer_oid = ""
             self.params.transformer_bucket = ""
@@ -275,7 +277,9 @@ class ModelWrapper(object):
         local_path = f"{self.output_dir}/transformers.pkl"
         if os.path.exists(local_path):
             self.log.info(f"Reloading transformers from model tarball {local_path}")
-            self.transformers, self.transformers_x = pickle.load(open(local_path, 'rb'))
+            txfmr=open(local_path, 'rb')
+            self.transformers, self.transformers_x = pickle.load(txfmr)
+            txfmr.close()
         else:
             if self.params.transformer_key is not None:
                 if self.params.save_results:
@@ -286,7 +290,9 @@ class ModelWrapper(object):
                         client = self.ds_client )
                 else:
                     self.log.info(f"Reloading transformers from file {self.params.transformer_key}")
-                    self.transformers, self.transformers_x = pickle.load(open( self.params.transformer_key, 'rb' ))
+                    txfmr=open( self.params.transformer_key, 'rb' )
+                    self.transformers, self.transformers_x = pickle.load(txfmr)
+                    txfmr.close()
             else:
                 # Shouldn't happen
                 raise Exception("Transformers needed to reload model, but no transformer_key specified.")

--- a/atomsci/ddm/pipeline/predict_from_model.py
+++ b/atomsci/ddm/pipeline/predict_from_model.py
@@ -60,7 +60,8 @@ def predict_from_tracker_model(model_uuid, collection, input_df, id_col='compoun
 
 # =====================================================================================================
 def predict_from_model_file(model_path, input_df, id_col='compound_id', smiles_col='rdkit_smiles',
-                     response_col=None, conc_col=None, is_featurized=False, dont_standardize=False, AD_method=None, k=5, dist_metric="euclidean"):
+                     response_col=None, conc_col=None, is_featurized=False, dont_standardize=False, AD_method=None, k=5, dist_metric="euclidean",
+                     external_training_data=None):
     """
     Loads a pretrained model from a model tarball file and runs predictions on compounds in an input
     data frame.
@@ -90,13 +91,16 @@ def predict_from_model_file(model_path, input_df, id_col='compound_id', smiles_c
         k (int): number of the neareast neighbors to evaluate the AD index, default is 5.
 
         dist_metric (str): distance metrics, valid values are 'cityblock', 'cosine', 'euclidean', 'jaccard', 'manhattan'
+        
+        external_training_data (str): path to where the dataset is if the model was originally trained elsewhere. For AD_index calc.
     Return: 
         A data frame with compound IDs, SMILES strings and predicted response values. Actual response values
         will be included if response_col is provided. Standard prediction error estimates will be included
         if the model was trained with uncertainty=True. Note that the predicted and actual response
         columns will be labeled according to the response_col setting in the original training data,
         not the response_col passed to this function; e.g. if the original model response_col was 'pIC50',
-        the returned data frame will contain columns 'pIC50_actual', 'pIC50_pred' and 'pIC50_std'.
+        the returned data frame will contain columns 'pIC50_actual', 'pIC50_pred' and 'pIC50_std'. For proper
+        ADI calculation, the original data column names must be preserved in the new data.
     """
 
     input_df, pred_params = _prepare_input_data(input_df, id_col, smiles_col, response_col, conc_col, dont_standardize)
@@ -105,6 +109,8 @@ def predict_from_model_file(model_path, input_df, id_col='compound_id', smiles_c
     pred_params = parse.wrapper(pred_params)
 
     pipe = mp.create_prediction_pipeline_from_file(pred_params, reload_dir=None, model_path=model_path)
+    if external_training_data is not None:
+        pipe.params.dataset_key=external_training_data
     pred_df = pipe.predict_full_dataset(input_df, contains_responses=has_responses, is_featurized=is_featurized,
                                         dset_params=pred_params, AD_method=AD_method, k=k, dist_metric=dist_metric)
     return pred_df

--- a/atomsci/ddm/utils/datastore_functions.py
+++ b/atomsci/ddm/utils/datastore_functions.py
@@ -35,6 +35,7 @@ try:
     from atomsci.clients import DatastoreClient
     from atomsci.clients import DatastoreClientSingleton
     from atomsci.clients import MLMTClient
+    from atomsci.clients import MLMTClientSingleton
 except (ModuleNotFoundError, ImportError):
     logger.info("atomsci.clients package missing, is currently unsupported for non-ATOM users.\n" +
                 "ATOM users should run 'pip install clients --user' to install.")
@@ -104,12 +105,12 @@ def config_client(
 
 #--------------------------------------------------------------------------------------------------------
 
-def initialize_model_tracker(): 
+def initialize_model_tracker(new_instance=False): 
     """
     Create or obtain a client object for the model tracker service..
 
     Returns:
-        mlmt_client (MLMTClient): The client object for the model tracker service.
+        mlmt_client (MLMTClientSingleton): The client object for the model tracker service.
     """
     if not clients_supported:
         raise Exception("Model tracker client not supported in current environment.")
@@ -120,7 +121,10 @@ def initialize_model_tracker():
     # MLMT service uses same API token as datastore. Make sure it gets set in the environment.
     ds_client = config_client()
 
-    mlmt_client = MLMTClient()
+    if new_instance:
+        mlmt_client = MLMTClient()
+    else:
+        mlmt_client = MLMTClientSingleton()
 
     return mlmt_client
 

--- a/atomsci/ddm/utils/hyperparam_search_wrapper.py
+++ b/atomsci/ddm/utils/hyperparam_search_wrapper.py
@@ -1016,15 +1016,16 @@ class HyperparameterSearch(object):
         Returns:
             None
         """
-        for assay_params in job_list:
-            i = int(run_cmd('squeue | grep $(whoami) | wc -l').decode("utf-8"))
-            while i >= self.params.max_jobs:
-                print("%d jobs in queue, sleeping" % i)
-                time.sleep(retry_time)
+        for assay_params in job_list: 
+            if len(self.filter_jobs([assay_params]))==1:
                 i = int(run_cmd('squeue | grep $(whoami) | wc -l').decode("utf-8"))
-            self.log.info(assay_params)
-            self.out_file.write(str(assay_params))
-            run_command(self.shell_script, self.params.python_path, self.params.script_dir, assay_params)
+                while i >= self.params.max_jobs:
+                    print("%d jobs in queue, sleeping" % i)
+                    time.sleep(retry_time)
+                    i = int(run_cmd('squeue | grep $(whoami) | wc -l').decode("utf-8"))
+                self.log.info(assay_params)
+                self.out_file.write(str(assay_params))
+                run_command(self.shell_script, self.params.python_path, self.params.script_dir, assay_params)
 
     def already_run(self, assay_params, retry_time=10):
         """
@@ -1048,7 +1049,7 @@ class HyperparameterSearch(object):
         i = 0
         while retry:
             try:
-                print("Checking model tracker DB for existing model with parameter combo.")
+                print(f"Checking model tracker DB for existing model with parameter combo in {assay_params['collection_name']} collection.")
                 models = list(trkr.get_full_metadata(filter_dict, collection_name=assay_params['collection_name']))
                 retry = False
             except Exception as e:
@@ -1103,8 +1104,8 @@ class HyperparameterSearch(object):
         self.generate_assay_list()
         print("build_ jobs")
         job_list = self.build_jobs()
-        print("filter redundant jobs")
-        job_list = self.filter_jobs(job_list)
+#         print("filter redundant jobs")
+#         job_list = self.filter_jobs(job_list)
 
         return job_list
 


### PR DESCRIPTION
In this pull request I am doing 3 main things:

- Updated hyperparameter search wrapper to change the order of the loop: instead of filtering all jobs first, I filter them one at a time and then submit. This is more stable (especially when querying the MT for 1000's of jobs) and allows for jobs to be submitted faster.
- Found a few hanging open files that I've updated the code to explicitly close them
- When a model is trained elsewhere, the ADI calculation looks in the original location for the original data. Here I extend the predict_from_model_file() function to allow for intake of a new path to the external training data. Then the dataset_key field in params is updated and the ADI calculation is able to proceed. In order for this to work, the original column names must be passed for the new data as well. There is also a try/catch so that if problems arise, predictions are still generated but the ADI is not calculated.