### PR TITLE
add bokeh to the pip install list

### DIFF
--- a/conda/pip_requirements.txt
+++ b/conda/pip_requirements.txt
@@ -5,6 +5,7 @@ astor==0.8.1
 astunparse==1.6.3
 attrs==20.3.0
 backcall==0.2.0
+bokeh==2.3.3
 bravado-core==5.17.0
 bravado==11.0.2
 cached-property==1.5.2


### PR DESCRIPTION
Added bokeh 2.3.3 to the pip install list.

To verify that it doesn't break other code and packages:

- create a new atomsci environment:
$ conda create -y -n atomsci_bokeh --file conda_package_list.txt
$ conda activate atomsci_bokeh
$ pip install -r pip_requirements.txt

Run test code:

$ cd atomsci/ddm/test/integrative/dataset_hash
$ pytest test_hash_checksum.py::test_uses_same_training_data_by_tars_delaney_train_NN 
$ pytest test_hash_checksum.py::test_uses_same_training_data_by_tars_nn_ecfp 
$ pytest test_hash_checksum.py::test_uses_same_training_data_not_equals_by_tars 

