### PR TITLE
Bug dc261 restore

### DIFF
--- a/atomsci/ddm/pipeline/model_wrapper.py
+++ b/atomsci/ddm/pipeline/model_wrapper.py
@@ -156,9 +156,9 @@ def create_model_wrapper(params, featurizer, ds_client=None):
     """
     if params.model_type == 'NN':
         if params.featurizer == 'graphconv':
-            return GraphConvDeepChemModelWrapper(params, featurizer, ds_client)
+            return GraphConvDCModelWrapper(params, featurizer, ds_client)
         else:
-            return MultiClassDeepChemModelWrapper(params, featurizer, ds_client)
+            return MultitaskDCModelWrapper(params, featurizer, ds_client)
     elif params.model_type == 'RF':
         return DCRFModelWrapper(params, featurizer, ds_client)
     elif params.model_type == 'xgboost':
@@ -2360,7 +2360,7 @@ class PytorchDeepChemModelWrapper(NNModelWrapper):
         self.model.restore()
 
 # ****************************************************************************************
-class MultiClassDeepChemModelWrapper(PytorchDeepChemModelWrapper):
+class MultitaskDCModelWrapper(PytorchDeepChemModelWrapper):
     """Contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
     generate predictions for an input dataset, and generate performance metrics for these predictions.
 
@@ -2487,7 +2487,7 @@ class MultiClassDeepChemModelWrapper(PytorchDeepChemModelWrapper):
         to neural network models.
 
         Returns:
-            model_spec_metdata (dict): A dictionary of the parameter sets for the MultiClassDeepChemModelWrapper object.
+            model_spec_metdata (dict): A dictionary of the parameter sets for the MultitaskDCModelWrapper object.
                 Parameters are saved under the key 'nn_specific' as a subdictionary.
         """
         
@@ -2561,7 +2561,7 @@ class KerasDeepChemModelWrapper(PytorchDeepChemModelWrapper):
         dc_restore(self.model, checkpoint, model_dir, session)
 
 # ****************************************************************************************
-class GraphConvDeepChemModelWrapper(KerasDeepChemModelWrapper):
+class GraphConvDCModelWrapper(KerasDeepChemModelWrapper):
     """Contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
     generate predictions for an input dataset, and generate performance metrics for these predictions.
 
@@ -2608,7 +2608,7 @@ class GraphConvDeepChemModelWrapper(KerasDeepChemModelWrapper):
     """
 
     def __init__(self, params, featurizer, ds_client):
-        """Initializes GraphConvDeepChemModelWrapper object.
+        """Initializes GraphConvDCModelWrapper object.
 
         Args:
             params (Namespace object): contains all parameter information.
@@ -2688,7 +2688,7 @@ class GraphConvDeepChemModelWrapper(KerasDeepChemModelWrapper):
         to neural network models.
 
         Returns:
-            model_spec_metdata (dict): A dictionary of the parameter sets for the GraphConvDeepChemModelWrapper object.
+            model_spec_metdata (dict): A dictionary of the parameter sets for the GraphConvDCModelWrapper object.
                 Parameters are saved under the key 'nn_specific' as a subdictionary.
         """
         nn_metadata = dict(

--- a/atomsci/ddm/pipeline/model_wrapper.py
+++ b/atomsci/ddm/pipeline/model_wrapper.py
@@ -55,6 +55,33 @@ import atomsci.ddm.pipeline.parameter_parser as pp
 
 logging.basicConfig(format='%(asctime)-15s %(message)s')
 
+def get_latest_pytorch_checkpoint(model, model_dir=None):
+    '''Gets the latest torch model
+
+    Calls get_checkpoints(), sorts them, and returns the
+    latest model (the one with the biggets number)
+
+    Args:
+        model: A model that inherits DeepChem TorchModel
+        model_dir: Optional argument that directs the model
+            to a specific folder
+
+    Returns:
+        path relative to model_dir, if provided, to the latest
+        checkpoint
+
+    '''
+    chkpts = model.get_checkpoints(model_dir)
+    print(chkpts)
+    if len(chkpts) == 0:
+        raise ValueError("No 'best' checkpoint found. deepchem.Model.get_checkpoints() is empty")
+    # checkpoint with the highest number is the best one
+    latest_chkpt = max(chkpts, key=os.path.getctime)
+    print(latest_chkpt)
+
+    return latest_chkpt
+ 
+
 def dc_restore(model, checkpoint=None, model_dir=None, session=None):
     """Reload the values of all variables from a checkpoint file.
 
@@ -126,7 +153,10 @@ def create_model_wrapper(params, featurizer, ds_client=None):
         ValueError: Only params.model_type = 'NN', 'RF' or 'xgboost' is supported.
     """
     if params.model_type == 'NN':
-        return DCNNModelWrapper(params, featurizer, ds_client)
+        if params.featurizer == 'graphconv':
+            return GraphConvDeepChemModelWrapper(params, featurizer, ds_client)
+        else:
+            return MultiClassDeepChemModelWrapper(params, featurizer, ds_client)
     elif params.model_type == 'RF':
         return DCRFModelWrapper(params, featurizer, ds_client)
     elif params.model_type == 'xgboost':
@@ -757,13 +787,6 @@ class NNModelWrapper(ModelWrapper):
         os.mkdir(dest_dir)
 
     # ****************************************************************************************
-    def restore(self, **kwargs):
-        '''
-        Restores the model to the last available checkpoint
-        '''
-        raise NotImplementedError
-
-    # ****************************************************************************************
     def train(self, pipeline):
         """Trains a neural net model for multiple epochs, choose the epoch with the best validation
         set performance, refits the model for that number of epochs, and saves the tuned model.
@@ -772,7 +795,7 @@ class NNModelWrapper(ModelWrapper):
             pipeline (ModelPipeline): The ModelPipeline instance for this model run.
 
         Side effects:
-            Sets the following attributes for DCNNModelWrapper:
+            Sets the following attributes for NNModelWrapper:
                 data (ModelDataset): contains the dataset, set in pipeline
 
                 best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
@@ -806,7 +829,7 @@ class NNModelWrapper(ModelWrapper):
             pipeline (ModelPipeline): The ModelPipeline instance for this model run.
 
         Side effects:
-            Sets the following attributes for DCNNModelWrapper:
+            Sets the following attributes for NNModelWrapper:
                 data (ModelDataset): contains the dataset, set in pipeline
 
                 best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
@@ -908,7 +931,7 @@ class NNModelWrapper(ModelWrapper):
             pipeline (ModelPipeline): The ModelPipeline instance for this model run.
 
         Side effects:
-            Sets the following attributes for DCNNModelWrapper:
+            Sets the following attributes for NNModelWrapper:
                 data (ModelDataset): contains the dataset, set in pipeline
 
                 best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
@@ -964,7 +987,26 @@ class NNModelWrapper(ModelWrapper):
         '''
         Reverts model to last saved checkpoint
         '''
-        dc_restore(self.model)
+        self.model.restore()
+        #dc_restore(self.model)
+
+    # ****************************************************************************************
+    def _copy_model(self, dest_dir):
+        """Copies the files needed to recreate a DeepChem NN model from the current model
+        directory to a destination directory.
+
+        Looks at self.model.get_checkpoints() and assumes the last checkpoint saved is the best
+
+        Args:
+            dest_dir (str): The destination directory for the model files
+        """
+        chkpt_file = get_latest_pytorch_checkpoint(self.model)
+
+        self._clean_up_excess_files(dest_dir)
+
+        shutil.copy2(chkpt_file, dest_dir)
+        self.log.info("Saved model files to '%s'" % dest_dir)
+
 
     # ****************************************************************************************
     def generate_predictions(self, dataset):
@@ -1036,386 +1078,6 @@ class NNModelWrapper(ModelWrapper):
                     pred = pred.reshape((pred.shape[0], pred.shape[1], 1))
         return pred, std
 
-# ****************************************************************************************
-class DCNNModelWrapper(NNModelWrapper):
-    """Contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
-    generate predictions for an input dataset, and generate performance metrics for these predictions.
-
-    Attributes:
-        Set in __init__
-            params (argparse.Namespace): The argparse.Namespace parameter object that contains all parameter information
-            featurziation (Featurization object): The featurization object created outside of model_wrapper
-
-            log (log): The logger
-
-            output_dir (str): The parent path of the model directory
-
-            transformers (list): Initialized as an empty list, stores the transformers on the response col
-
-            transformers_x (list): Initialized as an empty list, stores the transformers on the featurizers
-
-            model_dir (str): The subdirectory under output_dir that contains the model. Created in setup_model_dirs.
-
-            best_model_dir (str): The subdirectory under output_dir that contains the best model. Created in setup_model_dirs
-
-            g: The tensorflow graph object
-
-            sess: The tensor flow graph session
-
-            model: The dc.models.GraphConvModel, MultitaskRegressor, or MultitaskClassifier object, as specified by the params attribute
-
-        Created in train:
-            data (ModelDataset): contains the dataset, set in pipeline
-
-            best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
-
-            train_perf_data (np.array of PerfData): Initialized as an empty array, 
-                contains the predictions and performance of the training dataset
-
-            valid_perf_data (np.array of PerfData): Initialized as an empty array,
-                contains the predictions and performance of the validation dataset
-
-            train_epoch_perfs (np.array of dicts): Initialized as an empty array,
-                contains a list of dictionaries of predicted values and metrics on the training dataset
-
-            valid_epoch_perfs (np.array of dicts): Initialized as an empty array,
-                contains a list of dictionaries of predicted values and metrics on the validation dataset
-
-    """
-
-    def __init__(self, params, featurizer, ds_client):
-        """Initializes DCNNModelWrapper object.
-
-        Args:
-            params (Namespace object): contains all parameter information.
-
-            featurizer (Featurizer object): initialized outside of model_wrapper
-
-        Side effects:
-            params (argparse.Namespace): The argparse.Namespace parameter object that contains all parameter information
-
-            featurziation (Featurization object): The featurization object created outside of model_wrapper
-
-            log (log): The logger
-
-            output_dir (str): The parent path of the model directory
-
-            transformers (list): Initialized as an empty list, stores the transformers on the response col
-
-            transformers_x (list): Initialized as an empty list, stores the transformers on the featurizers
-
-            g: The tensorflow graph object
-
-            sess: The tensor flow graph session
-
-            model: The dc.models.GraphConvModel, MultitaskRegressor, or MultitaskClassifier object, as specified by the params attribute
-
-
-        """
-        super().__init__(params, featurizer, ds_client)
-        self.g = tf.Graph()
-        self.sess = tf.compat.v1.Session(graph=self.g)
-        n_features = self.get_num_features()
-        self.num_epochs_trained = 0
-        self.log.warning("This method is deprecated and will not be supported in the future")
-        if self.params.featurizer == 'graphconv':
-
-            # Set defaults for layer sizes and dropouts, if not specified by caller. Note that
-            # these depend on the featurizer used.
-
-            if self.params.layer_sizes is None:
-                self.params.layer_sizes = [64, 64, 128]
-            if self.params.dropouts is None:
-                if self.params.uncertainty:
-                    self.params.dropouts = [0.25] * len(self.params.layer_sizes)
-                else:
-                    self.params.dropouts = [0.0] * len(self.params.layer_sizes)
-
-            # TODO: Need to check that GraphConvModel params are actually being used
-            self.model = dc.models.GraphConvModel(
-                self.params.num_model_tasks,
-                batch_size=self.params.batch_size,
-                learning_rate=self.params.learning_rate,
-                learning_rate_decay_time=1000,
-                optimizer_type=self.params.optimizer_type,
-                beta1=0.9,
-                beta2=0.999,
-                model_dir=self.model_dir,
-                mode=self.params.prediction_type,
-                tensorboard=False,
-                uncertainty=self.params.uncertainty,
-                graph_conv_layers=self.params.layer_sizes[:-1],
-                dense_layer_size=self.params.layer_sizes[-1],
-                dropout=self.params.dropouts,
-                penalty=self.params.weight_decay_penalty,
-                penalty_type=self.params.weight_decay_penalty_type)
-
-        else:
-            # Set defaults for layer sizes and dropouts, if not specified by caller. Note that
-            # default layer sizes depend on the featurizer used.
-
-            if self.params.layer_sizes is None:
-                if self.params.featurizer == 'ecfp':
-                    self.params.layer_sizes = [1000, 500]
-                elif self.params.featurizer in ['descriptors', 'computed_descriptors']:
-                    self.params.layer_sizes = [200, 100]
-                else:
-                    # Shouldn't happen
-                    self.log.warning("You need to define default layer sizes for featurizer %s" %
-                                     self.params.featurizer)
-                    self.params.layer_sizes = [1000, 500]
-
-            if self.params.dropouts is None:
-                self.params.dropouts = [0.4] * len(self.params.layer_sizes)
-            if self.params.weight_init_stddevs is None:
-                self.params.weight_init_stddevs = [0.02] * len(self.params.layer_sizes)
-            if self.params.bias_init_consts is None:
-                self.params.bias_init_consts = [1.0] * len(self.params.layer_sizes)
-
-            if self.params.prediction_type == 'regression':
-
-                # TODO: Need to check that MultitaskRegressor params are actually being used
-                self.model = MultitaskRegressor(
-                    self.params.num_model_tasks,
-                    n_features,
-                    layer_sizes=self.params.layer_sizes,
-                    dropouts=self.params.dropouts,
-                    weight_init_stddevs=self.params.weight_init_stddevs,
-                    bias_init_consts=self.params.bias_init_consts,
-                    learning_rate=self.params.learning_rate,
-                    weight_decay_penalty=self.params.weight_decay_penalty,
-                    weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                    batch_size=self.params.batch_size,
-                    verbosity='low',
-                    model_dir=self.model_dir,
-                    learning_rate_decay_time=1000,
-                    beta1=0.9,
-                    beta2=0.999,
-                    mode=self.params.prediction_type,
-                    tensorboard=False,
-                    uncertainty=self.params.uncertainty)
-
-                # print("JEA debug",self.params.num_model_tasks,n_features,self.params.layer_sizes,self.params.weight_init_stddevs,self.params.bias_init_consts,self.params.dropouts,self.params.weight_decay_penalty,self.params.weight_decay_penalty_type,self.params.batch_size,self.params.learning_rate)
-                # self.model = MultitaskRegressor(
-                #     self.params.num_model_tasks,
-                #     n_features,
-                #     layer_sizes=self.params.layer_sizes,
-                #     weight_init_stddevs=self.params.weight_init_stddevs,
-                #     bias_init_consts=self.params.bias_init_consts,
-                #     dropouts=self.params.dropouts,
-                #     weight_decay_penalty=self.params.weight_decay_penalty,
-                #     weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                #     batch_size=self.params.batch_size,
-                #     learning_rate=self.params.learning_rate,
-                #     seed=123)
-
-            else:
-                # TODO: Need to check that MultitaskClassifier params are actually being used
-                self.model = MultitaskClassifier(
-                    self.params.num_model_tasks,
-                    n_features,
-                    layer_sizes=self.params.layer_sizes,
-                    dropouts=self.params.dropouts,
-                    weight_init_stddevs=self.params.weight_init_stddevs,
-                    bias_init_consts=self.params.bias_init_consts,
-                    learning_rate=self.params.learning_rate,
-                    weight_decay_penalty=self.params.weight_decay_penalty,
-                    weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                    batch_size=self.params.batch_size,
-                    verbosity='low',
-                    model_dir=self.model_dir,
-                    learning_rate_decay_time=1000,
-                    beta1=.9,
-                    beta2=.999,
-                    mode=self.params.prediction_type,
-                    tensorboard=False,
-                    n_classes=self.params.class_number)
-
-    # ****************************************************************************************
-    def recreate_model(self):
-        """
-        Creates a new DeepChem Model object of the correct type for the requested featurizer and prediction type 
-        and returns it.
-        """
-        if self.params.featurizer == 'graphconv':
-            model = dc.models.GraphConvModel(
-                self.params.num_model_tasks,
-                batch_size=self.params.batch_size,
-                learning_rate=self.params.learning_rate,
-                learning_rate_decay_time=1000,
-                optimizer_type=self.params.optimizer_type,
-                beta1=0.9,
-                beta2=0.999,
-                model_dir=self.model_dir,
-                mode=self.params.prediction_type,
-                tensorboard=False,
-                uncertainty=self.params.uncertainty,
-                graph_conv_layers=self.params.layer_sizes[:-1],
-                dense_layer_size=self.params.layer_sizes[-1],
-                dropout=self.params.dropouts,
-                penalty=self.params.weight_decay_penalty,
-                penalty_type=self.params.weight_decay_penalty_type)
-
-        else:
-            n_features = self.get_num_features()
-            if self.params.prediction_type == 'regression':
-                model = MultitaskRegressor(
-                    self.params.num_model_tasks,
-                    n_features,
-                    layer_sizes=self.params.layer_sizes,
-                    dropouts=self.params.dropouts,
-                    weight_init_stddevs=self.params.weight_init_stddevs,
-                    bias_init_consts=self.params.bias_init_consts,
-                    learning_rate=self.params.learning_rate,
-                    weight_decay_penalty=self.params.weight_decay_penalty,
-                    weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                    batch_size=self.params.batch_size,
-                    verbosity='low',
-                    model_dir=self.model_dir,
-                    learning_rate_decay_time=1000,
-                    beta1=0.9,
-                    beta2=0.999,
-                    mode=self.params.prediction_type,
-                    tensorboard=False,
-                    uncertainty=self.params.uncertainty)
-            else:
-                model = MultitaskClassifier(
-                    self.params.num_model_tasks,
-                    n_features,
-                    layer_sizes=self.params.layer_sizes,
-                    dropouts=self.params.dropouts,
-                    weight_init_stddevs=self.params.weight_init_stddevs,
-                    bias_init_consts=self.params.bias_init_consts,
-                    learning_rate=self.params.learning_rate,
-                    weight_decay_penalty=self.params.weight_decay_penalty,
-                    weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                    batch_size=self.params.batch_size,
-                    verbosity='low',
-                    model_dir=self.model_dir,
-                    learning_rate_decay_time=1000,
-                    beta1=.9,
-                    beta2=.999,
-                    mode=self.params.prediction_type,
-                    tensorboard=False,
-                    n_classes=self.params.class_number)
-
-        return model
-
-    # ****************************************************************************************
-    def _copy_model(self, dest_dir):
-        """Copies the files needed to recreate a DeepChem NN model from the current model
-        directory to a destination directory.
-
-        Args:
-            dest_dir (str): The destination directory for the model files
-        """
-
-        chkpt_file = os.path.join(self.model_dir, 'checkpoint')
-        with open(chkpt_file, 'r') as chkpt_in:
-            chkpt_dict = yaml.load(chkpt_in.read())
-        chkpt_prefix = chkpt_dict['model_checkpoint_path']
-        files = [chkpt_file]
-        # files.append(os.path.join(self.model_dir, 'model.pickle'))
-        files.append(os.path.join(self.model_dir, '%s.index' % chkpt_prefix))
-        # files.append(os.path.join(self.model_dir, '%s.meta' % chkpt_prefix))
-        files = files + glob.glob(os.path.join(self.model_dir, '%s.data-*' % chkpt_prefix))
-        self._clean_up_excess_files(dest_dir)
-        for file in files:
-            shutil.copy2(file, dest_dir)
-        self.log.info("Saved model files to '%s'" % dest_dir)
-
-    # ****************************************************************************************
-    def reload_model(self, reload_dir):
-        """Loads a saved neural net model from the specified directory.
-
-        Args:
-            reload_dir (str): Directory where saved model is located.
-            model_dataset (ModelDataset Object): contains the current full dataset
-
-        Side effects:
-            Resets the value of model, transformers, transformers_x and transformers_w
-        """
-        if self.params.featurizer == 'graphconv':
-            self.model = dc.models.GraphConvModel(
-                n_tasks=self.params.num_model_tasks,
-                n_features=self.get_num_features(),
-                batch_size=self.params.batch_size,
-                model_dir=reload_dir,
-                uncertainty=self.params.uncertainty,
-                graph_conv_layers=self.params.layer_sizes[:-1],
-                dense_layer_size=self.params.layer_sizes[-1],
-                dropout=self.params.dropouts,
-                learning_rate=self.params.learning_rate,
-                mode=self.params.prediction_type)
-        elif self.params.prediction_type == 'regression':
-            self.model = MultitaskRegressor(
-                self.params.num_model_tasks,
-                n_features=self.get_num_features(),
-                layer_sizes=self.params.layer_sizes,
-                dropouts=self.params.dropouts,
-                weight_init_stddevs=self.params.weight_init_stddevs,
-                bias_init_consts=self.params.bias_init_consts,
-                weight_decay_penalty=self.params.weight_decay_penalty,
-                weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                model_dir=reload_dir,
-                learning_rate=self.params.learning_rate,
-                uncertainty=self.params.uncertainty)
-        else:
-            self.model = MultitaskClassifier(
-                self.params.num_model_tasks,
-                n_features=self.get_num_features(),
-                layer_sizes=self.params.layer_sizes,
-                dropouts=self.params.dropouts,
-                weight_init_stddevs=self.params.weight_init_stddevs,
-                bias_init_consts=self.params.bias_init_consts,
-                weight_decay_penalty=self.params.weight_decay_penalty,
-                weight_decay_penalty_type=self.params.weight_decay_penalty_type,
-                model_dir=reload_dir,
-                learning_rate=self.params.learning_rate,
-                n_classes=self.params.class_number)
-        # Hack to run models trained in DeepChem 2.1 with DeepChem 2.2
-        # self.model.default_outputs = self.model.outputs
-        # Get latest checkpoint path transposed to current model dir
-        ckpt = tf.train.get_checkpoint_state(reload_dir)
-        if os.path.exists(f"{ckpt.model_checkpoint_path}.index"):
-            checkpoint = ckpt.model_checkpoint_path
-        else:
-            checkpoint = os.path.join(reload_dir, os.path.basename(ckpt.model_checkpoint_path))
-        dc_restore(self.model, checkpoint=checkpoint)
-
-
-        # Restore the transformers from the datastore or filesystem
-        self.reload_transformers()
-
-    # ****************************************************************************************
-    def restore(self):
-        dc_restore(self.model)
-
-    # ****************************************************************************************
-    def get_model_specific_metadata(self):
-        """Returns a dictionary of parameter settings for this ModelWrapper object that are specific
-        to neural network models.
-
-        Returns:
-            model_spec_metdata (dict): A dictionary of the parameter sets for the DCNNModelWrapper object.
-                Parameters are saved under the key 'nn_specific' as a subdictionary.
-        """
-        nn_metadata = dict(
-                    best_epoch = self.best_epoch,
-                    max_epochs = self.params.max_epochs,
-                    batch_size = self.params.batch_size,
-                    optimizer_type = self.params.optimizer_type,
-                    layer_sizes = self.params.layer_sizes,
-                    dropouts = self.params.dropouts,
-                    weight_init_stddevs = self.params.weight_init_stddevs,
-                    bias_init_consts = self.params.bias_init_consts,
-                    learning_rate = self.params.learning_rate,
-                    weight_decay_penalty=self.params.weight_decay_penalty,
-                    weight_decay_penalty_type=self.params.weight_decay_penalty_type
-        )
-        model_spec_metadata = dict(nn_specific = nn_metadata)
-        return model_spec_metadata
-       
 # ****************************************************************************************
 class HybridModelWrapper(NNModelWrapper):
     """A wrapper for hybrid models, contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
@@ -2621,7 +2283,7 @@ class PytorchDeepChemModelWrapper(NNModelWrapper):
             featurizer (Featurization): Object managing the featurization of compounds
             ds_client: datastore client.
         """
-        # use NNModelWrapper init. Not DCNNModelWrapper
+        # use NNModelWrapper init. 
         super().__init__(params, featurizer, ds_client)
         self.num_epochs_trained = 0
 
@@ -2668,10 +2330,8 @@ class PytorchDeepChemModelWrapper(NNModelWrapper):
             Resets the value of model, transformers, and transformers_x
         """
         self.model = self.recreate_model(model_dir=reload_dir)
-        chkpts = self.model.get_checkpoints()
-
         # checkpoint with the highest number is the best one
-        best_chkpt = sorted(chkpts)[0] 
+        best_chkpt = get_latest_pytorch_checkpoint(self.model)
         self.model.restore(best_chkpt, reload_dir)
 
         # Restore the transformers from the datastore or filesystem
@@ -2683,7 +2343,7 @@ class PytorchDeepChemModelWrapper(NNModelWrapper):
         to neural network models.
 
         Returns:
-            model_spec_metdata (dict): A dictionary of the parameter sets for the DCNNModelWrapper object.
+            model_spec_metdata (dict): A dictionary of the parameter sets for the NNModelWrapper object.
                 Parameters are saved under the key 'nn_specific' as a subdictionary.
         """
         nn_metadata = pp.extract_model_params(self.params, strip_prefix=False)
@@ -2698,26 +2358,155 @@ class PytorchDeepChemModelWrapper(NNModelWrapper):
         '''
         self.model.restore()
 
-    # ****************************************************************************************
-    def _copy_model(self, dest_dir):
-        """Copies the files needed to recreate a DeepChem NN model from the current model
-        directory to a destination directory.
+# ****************************************************************************************
+class MultiClassDeepChemModelWrapper(PytorchDeepChemModelWrapper):
+    """Contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
+    generate predictions for an input dataset, and generate performance metrics for these predictions.
 
-        Looks at self.model.get_checkpoints() and assumes the last checkpoint saved is the best
+    Attributes:
+        Set in __init__
+            params (argparse.Namespace): The argparse.Namespace parameter object that contains all parameter information
+            featurziation (Featurization object): The featurization object created outside of model_wrapper
 
-        Args:
-            dest_dir (str): The destination directory for the model files
+            log (log): The logger
+
+            output_dir (str): The parent path of the model directory
+
+            transformers (list): Initialized as an empty list, stores the transformers on the response col
+
+            transformers_x (list): Initialized as an empty list, stores the transformers on the featurizers
+
+            model_dir (str): The subdirectory under output_dir that contains the model. Created in setup_model_dirs.
+
+            best_model_dir (str): The subdirectory under output_dir that contains the best model. Created in setup_model_dirs
+
+            g: The tensorflow graph object
+
+            sess: The tensor flow graph session
+
+            model: The dc.models.GraphConvModel, MultitaskRegressor, or MultitaskClassifier object, as specified by the params attribute
+
+        Created in train:
+            data (ModelDataset): contains the dataset, set in pipeline
+
+            best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
+
+            train_perf_data (np.array of PerfData): Initialized as an empty array, 
+                contains the predictions and performance of the training dataset
+
+            valid_perf_data (np.array of PerfData): Initialized as an empty array,
+                contains the predictions and performance of the validation dataset
+
+            train_epoch_perfs (np.array of dicts): Initialized as an empty array,
+                contains a list of dictionaries of predicted values and metrics on the training dataset
+
+            valid_epoch_perfs (np.array of dicts): Initialized as an empty array,
+                contains a list of dictionaries of predicted values and metrics on the validation dataset
+
+    """
+
+    def recreate_model(self, model_dir=None):
         """
-        chkpts = sorted(self.model.get_checkpoints())
-        if len(chkpts) == 0:
-            raise ValueError("No 'best' checkpoint found. deepchem.Model.get_checkpoints() is empty")
-        chkpt_file = chkpts[0] # most recent is best
+        Creates a new DeepChem Model object of the correct type for the requested featurizer and prediction type 
+        and returns it.
 
-        self._clean_up_excess_files(dest_dir)
+        reload_dir (str): Directory where saved model is located.
+        """
+        if model_dir is None:
+            model_dir = self.model_dir
 
-        shutil.copy2(chkpt_file, dest_dir)
-        self.log.info("Saved model files to '%s'" % dest_dir)
+        n_features = self.get_num_features()
+        if self.params.layer_sizes is None:
+            if self.params.featurizer == 'ecfp':
+                self.params.layer_sizes = [1000, 500]
+            elif self.params.featurizer in ['descriptors', 'computed_descriptors']:
+                self.params.layer_sizes = [200, 100]
+            else:
+                # Shouldn't happen
+                self.log.warning("You need to define default layer sizes for featurizer %s" %
+                                    self.params.featurizer)
+                self.params.layer_sizes = [1000, 500]
 
+        if self.params.dropouts is None:
+            self.params.dropouts = [0.4] * len(self.params.layer_sizes)
+        if self.params.weight_init_stddevs is None:
+            self.params.weight_init_stddevs = [0.02] * len(self.params.layer_sizes)
+        if self.params.bias_init_consts is None:
+            self.params.bias_init_consts = [1.0] * len(self.params.layer_sizes)
+
+        if self.params.prediction_type == 'regression':
+
+            # TODO: Need to check that MultitaskRegressor params are actually being used
+            model = MultitaskRegressor(
+                self.params.num_model_tasks,
+                n_features,
+                layer_sizes=self.params.layer_sizes,
+                dropouts=self.params.dropouts,
+                weight_init_stddevs=self.params.weight_init_stddevs,
+                bias_init_consts=self.params.bias_init_consts,
+                learning_rate=self.params.learning_rate,
+                weight_decay_penalty=self.params.weight_decay_penalty,
+                weight_decay_penalty_type=self.params.weight_decay_penalty_type,
+                batch_size=self.params.batch_size,
+                verbosity='low',
+                model_dir=model_dir,
+                learning_rate_decay_time=1000,
+                beta1=0.9,
+                beta2=0.999,
+                mode=self.params.prediction_type,
+                tensorboard=False,
+                uncertainty=self.params.uncertainty)
+        else:
+            # TODO: Need to check that MultitaskClassifier params are actually being used
+            model = MultitaskClassifier(
+                self.params.num_model_tasks,
+                n_features,
+                layer_sizes=self.params.layer_sizes,
+                dropouts=self.params.dropouts,
+                weight_init_stddevs=self.params.weight_init_stddevs,
+                bias_init_consts=self.params.bias_init_consts,
+                learning_rate=self.params.learning_rate,
+                weight_decay_penalty=self.params.weight_decay_penalty,
+                weight_decay_penalty_type=self.params.weight_decay_penalty_type,
+                batch_size=self.params.batch_size,
+                verbosity='low',
+                model_dir=model_dir,
+                learning_rate_decay_time=1000,
+                beta1=.9,
+                beta2=.999,
+                mode=self.params.prediction_type,
+                tensorboard=False,
+                n_classes=self.params.class_number)
+
+        return model
+
+    # ****************************************************************************************
+    def get_model_specific_metadata(self):
+        """Returns a dictionary of parameter settings for this ModelWrapper object that are specific
+        to neural network models.
+
+        Returns:
+            model_spec_metdata (dict): A dictionary of the parameter sets for the MultiClassDeepChemModelWrapper object.
+                Parameters are saved under the key 'nn_specific' as a subdictionary.
+        """
+        
+        nn_metadata = dict(
+                    best_epoch = self.best_epoch,
+                    max_epochs = self.params.max_epochs,
+                    batch_size = self.params.batch_size,
+                    optimizer_type = self.params.optimizer_type,
+                    layer_sizes = self.params.layer_sizes,
+                    dropouts = self.params.dropouts,
+                    weight_init_stddevs = self.params.weight_init_stddevs,
+                    bias_init_consts = self.params.bias_init_consts,
+                    learning_rate = self.params.learning_rate,
+                    weight_decay_penalty=self.params.weight_decay_penalty,
+                    weight_decay_penalty_type=self.params.weight_decay_penalty_type
+        )
+        model_spec_metadata = dict(nn_specific = nn_metadata)
+        return model_spec_metadata
+
+# ****************************************************************************************
 class KerasDeepChemModelWrapper(PytorchDeepChemModelWrapper):
     def _copy_model(self, dest_dir):
         """Copies the files needed to recreate a DeepChem NN model from the current model
@@ -2759,13 +2548,162 @@ class KerasDeepChemModelWrapper(PytorchDeepChemModelWrapper):
             checkpoint = ckpt.model_checkpoint_path
         else:
             checkpoint = os.path.join(reload_dir, os.path.basename(ckpt.model_checkpoint_path))
-        dc_restore(self.model, checkpoint=checkpoint)
+        self.restore(checkpoint=checkpoint)
 
         # Restore the transformers from the datastore or filesystem
         self.reload_transformers()
 
-    def restore(self):
+    def restore(self, checkpoint=None, model_dir=None, session=None):
         '''
         Restores this model
         '''
-        dc_restore(self.model)
+        dc_restore(self.model, checkpoint, model_dir, session)
+
+# ****************************************************************************************
+class GraphConvDeepChemModelWrapper(KerasDeepChemModelWrapper):
+    """Contains methods to load in a dataset, split and featurize the data, fit a model to the train dataset,
+    generate predictions for an input dataset, and generate performance metrics for these predictions.
+
+    Attributes:
+        Set in __init__
+            params (argparse.Namespace): The argparse.Namespace parameter object that contains all parameter information
+            featurziation (Featurization object): The featurization object created outside of model_wrapper
+
+            log (log): The logger
+
+            output_dir (str): The parent path of the model directory
+
+            transformers (list): Initialized as an empty list, stores the transformers on the response col
+
+            transformers_x (list): Initialized as an empty list, stores the transformers on the featurizers
+
+            model_dir (str): The subdirectory under output_dir that contains the model. Created in setup_model_dirs.
+
+            best_model_dir (str): The subdirectory under output_dir that contains the best model. Created in setup_model_dirs
+
+            g: The tensorflow graph object
+
+            sess: The tensor flow graph session
+
+            model: The dc.models.GraphConvModel, MultitaskRegressor, or MultitaskClassifier object, as specified by the params attribute
+
+        Created in train:
+            data (ModelDataset): contains the dataset, set in pipeline
+
+            best_epoch (int): Initialized as None, keeps track of the epoch with the best validation score
+
+            train_perf_data (np.array of PerfData): Initialized as an empty array, 
+                contains the predictions and performance of the training dataset
+
+            valid_perf_data (np.array of PerfData): Initialized as an empty array,
+                contains the predictions and performance of the validation dataset
+
+            train_epoch_perfs (np.array of dicts): Initialized as an empty array,
+                contains a list of dictionaries of predicted values and metrics on the training dataset
+
+            valid_epoch_perfs (np.array of dicts): Initialized as an empty array,
+                contains a list of dictionaries of predicted values and metrics on the validation dataset
+
+    """
+
+    def __init__(self, params, featurizer, ds_client):
+        """Initializes GraphConvDeepChemModelWrapper object.
+
+        Args:
+            params (Namespace object): contains all parameter information.
+
+            featurizer (Featurizer object): initialized outside of model_wrapper
+
+        Side effects:
+            params (argparse.Namespace): The argparse.Namespace parameter object that contains all parameter information
+
+            featurziation (Featurization object): The featurization object created outside of model_wrapper
+
+            log (log): The logger
+
+            output_dir (str): The parent path of the model directory
+
+            transformers (list): Initialized as an empty list, stores the transformers on the response col
+
+            transformers_x (list): Initialized as an empty list, stores the transformers on the featurizers
+
+            g: The tensorflow graph object
+
+            sess: The tensor flow graph session
+
+            model: The dc.models.GraphConvModel, MultitaskRegressor, or MultitaskClassifier object, as specified by the params attribute
+
+
+        """
+        super().__init__(params, featurizer, ds_client)
+        self.g = tf.Graph()
+        self.sess = tf.compat.v1.Session(graph=self.g)
+        self.num_epochs_trained = 0
+
+        self.model = self.recreate_model(model_dir=self.model_dir)
+
+    # ****************************************************************************************
+    def recreate_model(self, model_dir=None):
+        """
+        Creates a new DeepChem Model object of the correct type for the requested featurizer and prediction type 
+        and returns it.
+
+        reload_dir (str): Directory where saved model is located.
+        """
+        if model_dir is None:
+            model_dir = self.model_dir
+
+        # Set defaults for layer sizes and dropouts, if not specified by caller. Note that
+        if self.params.layer_sizes is None:
+            self.params.layer_sizes = [64, 64, 128]
+        if self.params.dropouts is None:
+            if self.params.uncertainty:
+                self.params.dropouts = [0.25] * len(self.params.layer_sizes)
+            else:
+                self.params.dropouts = [0.0] * len(self.params.layer_sizes)
+
+        model = dc.models.GraphConvModel(
+            self.params.num_model_tasks,
+            batch_size=self.params.batch_size,
+            learning_rate=self.params.learning_rate,
+            learning_rate_decay_time=1000,
+            optimizer_type=self.params.optimizer_type,
+            beta1=0.9,
+            beta2=0.999,
+            model_dir=model_dir,
+            mode=self.params.prediction_type,
+            tensorboard=False,
+            uncertainty=self.params.uncertainty,
+            graph_conv_layers=self.params.layer_sizes[:-1],
+            dense_layer_size=self.params.layer_sizes[-1],
+            dropout=self.params.dropouts,
+            penalty=self.params.weight_decay_penalty,
+            penalty_type=self.params.weight_decay_penalty_type)
+        return model
+
+    # ****************************************************************************************
+    def get_model_specific_metadata(self):
+        """Returns a dictionary of parameter settings for this ModelWrapper object that are specific
+        to neural network models.
+
+        Returns:
+            model_spec_metdata (dict): A dictionary of the parameter sets for the GraphConvDeepChemModelWrapper object.
+                Parameters are saved under the key 'nn_specific' as a subdictionary.
+        """
+        nn_metadata = dict(
+                    best_epoch = self.best_epoch,
+                    max_epochs = self.params.max_epochs,
+                    batch_size = self.params.batch_size,
+                    optimizer_type = self.params.optimizer_type,
+                    layer_sizes = self.params.layer_sizes,
+                    dropouts = self.params.dropouts,
+                    weight_init_stddevs = self.params.weight_init_stddevs,
+                    bias_init_consts = self.params.bias_init_consts,
+                    learning_rate = self.params.learning_rate,
+                    weight_decay_penalty=self.params.weight_decay_penalty,
+                    weight_decay_penalty_type=self.params.weight_decay_penalty_type
+        )
+        model_spec_metadata = dict(nn_specific = nn_metadata)
+        return model_spec_metadata
+
+

--- a/atomsci/ddm/pipeline/parameter_parser.py
+++ b/atomsci/ddm/pipeline/parameter_parser.py
@@ -1060,7 +1060,7 @@ def get_parser():
         ('Comma-separated list of initial bias parameters per layer for dense NN models with conditional values. '
          'Defaults to [1.0]*len(layer_sizes). Must be same length as layer_sizes. Can be input as a space-separated '
          'list of comma-separated lists for hyperparameters (e.g. \'1.0,1.0 0.9,0.9 0.8,0.9\'). Default behavior is'
-         ' set within __init__ method of DCNNModelWrapper.  '
+         ' set within __init__ method of relevant ModelWrapper class.  '
          + separator.join(temp_bias_init_consts_string)).rstrip(',')
     parser.add_argument(
         '--bias_init_consts', dest='bias_init_consts', required=False, default=None,
@@ -1072,7 +1072,7 @@ def get_parser():
         ('Comma-separated list of dropout rates per layer for NN models with default values conditional on featurizer.'
          ' Default behavior is controlled in model_wrapper.py. Must be same length as layer_sizes. Can be input as '
          'a space-separated list of comma-separated lists for hyperparameters (e.g. \'0.4,0.4 0.2,0.2 0.3,0.3\'). '
-         'Default behavior is set within __init__ method of DCNNModelWrapper. Defaults: '
+         'Default behavior is set within __init__ method of relevant ModelWrapper class. Defaults: '
          + separator.join(temp_dropout_string)).rstrip(',')
     parser.add_argument(
         '--dropouts', dest='dropouts', required=False, default=None,
@@ -1084,7 +1084,7 @@ def get_parser():
         ('Comma-separated list of layer sizes for NN models with default values conditional on featurizer. Must be'
          ' same length as layer_sizes. Can be input as a space-separated list of comma-separated lists for '
          'hyperparameters (e.g. \'64,16 200,100 1000,500\'). Default behavior is set within __init__ method of '
-         'DCNNModelWrapper. Defaults: '
+         'relevant ModelWrapper class. Defaults: '
          + separator.join(temp_layer_size_string)).rstrip(',')
     parser.add_argument(
         '--layer_sizes', dest='layer_sizes', required=False, default=None,
@@ -1113,7 +1113,7 @@ def get_parser():
         ('Comma-separated list of standard deviations per layer for initializing weights in dense NN models with '
          'conditional values. Must be same length as layer_sizes. Can be input as a space-separated list of '
          'comma-separated lists for hyperparameters (e.g. \'0.001,0.001 0.002,0.002 0.03,003\'). Default behavior is '
-         'set within __init__ method of DCNNModelWrapper. Defaults: '
+         'set within __init__ method of relevant ModelWrapper class. Defaults: '
          + separator.join(temp_weight_init_stddevs_string)).rstrip(',')
     parser.add_argument(
         '--weight_init_stddevs', dest='weight_init_stddevs', required=False, default=None,

--- a/atomsci/ddm/test/unit/test_model_wrapper.py
+++ b/atomsci/ddm/test/unit/test_model_wrapper.py
@@ -63,7 +63,7 @@ Dependencies:
 None
 
 Calls:
-MultiClassDeepChemModelWrapper, DCRFModelWrapper
+MultitaskDCModelWrapper, DCRFModelWrapper
     """
     inp_params = parse.wrapper(general_params)
     featurization = feat.create_featurization(inp_params)
@@ -79,7 +79,7 @@ MultiClassDeepChemModelWrapper, DCRFModelWrapper
     test.append(mdl.best_model_dir == inp_params.output_dir + '/' + 'best_model')
     test.append(mdl.transformers == [])
     test.append(mdl.transformers_x == [])
-    test.append(isinstance(mdl, model_wrapper.MultiClassDeepChemModelWrapper))
+    test.append(isinstance(mdl, model_wrapper.MultitaskDCModelWrapper))
 
     # testing for correct attribute initialization with model_type == "RF"
     temp_params = copy.deepcopy(inp_params)

--- a/atomsci/ddm/test/unit/test_model_wrapper.py
+++ b/atomsci/ddm/test/unit/test_model_wrapper.py
@@ -63,7 +63,7 @@ Dependencies:
 None
 
 Calls:
-DCNNModelWrapper, DCRFModelWrapper
+MultiClassDeepChemModelWrapper, DCRFModelWrapper
     """
     inp_params = parse.wrapper(general_params)
     featurization = feat.create_featurization(inp_params)
@@ -79,7 +79,7 @@ DCNNModelWrapper, DCRFModelWrapper
     test.append(mdl.best_model_dir == inp_params.output_dir + '/' + 'best_model')
     test.append(mdl.transformers == [])
     test.append(mdl.transformers_x == [])
-    test.append(isinstance(mdl, model_wrapper.DCNNModelWrapper))
+    test.append(isinstance(mdl, model_wrapper.MultiClassDeepChemModelWrapper))
 
     # testing for correct attribute initialization with model_type == "RF"
     temp_params = copy.deepcopy(inp_params)


### PR DESCRIPTION
DeepChem changed the Multitask models over to Pytorch. As a result the DCNNModelWrapper can't wrap both the GraphConv (keras) and the Multitask (Pytorch) models anymore, because of the copy and saving functions. the DCNNModelWrapper is removed and split into 2 classes, GraphConvDCModelWrapper and MultitaskDCModelWrapper. These inherit the KerasDeepChemModelWrapper and PytorchDeepChemModelWrapper respectively.