### PR TITLE
Replace dc.data.DiskDataset with NumpyDataset and otherwise reduce creation of temp files

### DIFF
--- a/atomsci/ddm/pipeline/MultitaskScaffoldSplit.py
+++ b/atomsci/ddm/pipeline/MultitaskScaffoldSplit.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from functools import partial
 
 import deepchem as dc
-from deepchem.data import Dataset, DiskDataset
+from deepchem.data import Dataset, NumpyDataset
 from deepchem.splits import Splitter
 from deepchem.splits.splitters import _generate_scaffold
 
@@ -716,16 +716,16 @@ class MultitaskScaffoldSplitter(Splitter):
         train_dir: str, optional (default None)
             If specified, the directory in which the generated
             training dataset should be stored. This is only
-            considered if `isinstance(dataset, dc.data.DiskDataset)`
+            considered if `isinstance(dataset, dc.data.Dataset)`
         valid_dir: str, optional (default None)
             If specified, the directory in which the generated
             valid dataset should be stored. This is only
-            considered if `isinstance(dataset, dc.data.DiskDataset)`
+            considered if `isinstance(dataset, dc.data.Dataset)`
             is True.
         test_dir: str, optional (default None)
             If specified, the directory in which the generated
             test dataset should be stored. This is only
-            considered if `isinstance(dataset, dc.data.DiskDataset)`
+            considered if `isinstance(dataset, dc.data.Dataset)`
             is True.
 
         Returns
@@ -752,7 +752,7 @@ class MultitaskScaffoldSplitter(Splitter):
         train_dataset = dataset.select(train_inds, train_dir)
         valid_dataset = dataset.select(valid_inds, valid_dir)
         test_dataset = dataset.select(test_inds, test_dir)
-        if isinstance(train_dataset, DiskDataset):
+        if isinstance(train_dataset, Dataset):
             train_dataset.memory_cache_size = 40 * (1 << 20)  # 40 MB
 
         return train_dataset, valid_dataset, test_dataset
@@ -878,7 +878,7 @@ def split_using_MultitaskScaffoldSplit(df: pd.DataFrame,
     ids = df[smiles_col].values
 
     # build deepchem Dataset
-    dataset = dc.data.DiskDataset.from_numpy(X, y, w=w, ids=ids)
+    dataset = dc.data.NumpyDataset(X, y, w=w, ids=ids)
     mss = MultitaskScaffoldSplitter()
     splits = mss.split(dataset, **kwargs)
 
@@ -902,7 +902,7 @@ def split_with(df, splitter, smiles_col, id_col, response_cols, **kwargs):
     y, w = make_y_w(df, response_cols)
     ids = df[smiles_col].values
 
-    dataset = dc.data.DiskDataset.from_numpy(X, y, w=w, ids=ids)
+    dataset = dc.data.NumpyDataset(X, y, w=w, ids=ids)
 
     splits = splitter.split(dataset, **kwargs)
 

--- a/atomsci/ddm/pipeline/model_datasets.py
+++ b/atomsci/ddm/pipeline/model_datasets.py
@@ -5,7 +5,7 @@
 import logging
 import os
 import shutil
-from deepchem.data import DiskDataset
+from deepchem.data import NumpyDataset
 import numpy as np
 import pandas as pd
 import deepchem as dc
@@ -245,11 +245,11 @@ class ModelDataset(object):
             
             splitting (Splitting object): A splitting object created by the ModelDataset intiailization method
             
-            combined_train_valid_data (dc.DiskDataset): A dataset object (initialized as None), of the merged train
+            combined_train_valid_data (dc.Dataset): A dataset object (initialized as None), of the merged train
             and valid splits
 
         set in get_featurized_data:
-            dataset: A new featurized DeepChem DiskDataset.
+            dataset: A new featurized DeepChem Dataset.
             
             n_features: The count of features (int)
             
@@ -345,7 +345,7 @@ class ModelDataset(object):
 
         Side effects:
             Sets the following attributes in the ModelDataset object:
-                dataset: A new featurized DeepChem DiskDataset.
+                dataset: A new featurized DeepChem Dataset.
                 n_features: The count of features (int)
                 vals: The response col after featurization (np.array)
                 attr: A pd.dataframe containing the compound ids and smiles
@@ -375,7 +375,7 @@ class ModelDataset(object):
                 if params.prediction_type=='classification':
                     w = w.astype(np.float32)
 
-                self.dataset = DiskDataset.from_numpy(features, self.vals, ids=ids, w=w)
+                self.dataset = NumpyDataset(features, self.vals, ids=ids, w=w)
                 self.log.info("Using prefeaturized data; number of features = " + str(self.n_features))
                 return
             except Exception as e:
@@ -398,7 +398,7 @@ class ModelDataset(object):
         self.log.debug("Number of features: " + str(self.n_features))
            
         # Create the DeepChem dataset       
-        self.dataset = DiskDataset.from_numpy(features, self.vals, ids=ids, w=w)
+        self.dataset = NumpyDataset(features, self.vals, ids=ids, w=w)
         # Checking for minimum number of rows
         if len(self.dataset) < params.min_compound_number:
             self.log.warning("Dataset of length %i is shorter than the required length %i" % (len(self.dataset), params.min_compound_number))
@@ -618,7 +618,7 @@ class ModelDataset(object):
         """Returns a DeepChem Dataset object containing data for the combined training & validation compounds.
 
         Returns:
-            combined_dataset (dc.data.DiskDataset): Dataset containing the combined training
+            combined_dataset (dc.data.Dataset): Dataset containing the combined training
             and validation data.
             
         Side effects:
@@ -632,7 +632,7 @@ class ModelDataset(object):
             combined_y = np.concatenate((train.y, valid.y), axis=0)
             combined_w = np.concatenate((train.w, valid.w), axis=0)
             combined_ids = np.concatenate((train.ids, valid.ids))
-            self.combined_train_valid_data = DiskDataset.from_numpy(combined_X, combined_y, w=combined_w, ids=combined_ids)
+            self.combined_train_valid_data = NumpyDataset(combined_X, combined_y, w=combined_w, ids=combined_ids)
         return self.combined_train_valid_data
 
     # ****************************************************************************************
@@ -725,7 +725,7 @@ class MinimalDataset(ModelDataset):
             featurization (Featurization object): The featurization object created by ModelDataset or input as an optional argument in the factory function.
 
         set in get_featurized_data:
-            dataset: A new featurized DeepChem DiskDataset.
+            dataset: A new featurized DeepChem Dataset.
             n_features: The count of features (int)
             attr: A pd.dataframe containing the compound ids and smiles
 
@@ -816,24 +816,7 @@ class MinimalDataset(ModelDataset):
                                                                                     params, self.contains_responses)
             self.log.warning("Done")
         self.n_features = self.featurization.get_feature_count()
-        print("number of features: " + str(self.n_features))
-        # Create the DeepChem dataset
-        # TODO: Try this with NumpyDataset instead. It may require special handling in ModelWrapper
-        # classes, because NumpyDataset.y has different dimensionality than DiskDataset.y for the
-        # same singletask dataset. Or it may not, since we aren't comparing predictions against real
-        # values for MinimalDataset objects.
-        #self.dataset = NumpyDataset(features, self.vals, ids=ids)
-
-        # =-= ksm: This makes no sense, since MinimalDataset doesn't get used for training, so the splitting
-        # =-= parameter is irrelevant. Looks like I made this change on 10/2/2019 at the same time I implemented
-        # =-= the temporal splitter. For now I'm commenting out the code, because it breaks the 
-        # =-= EmbeddingFeaturization with input descriptor features.
-        #if self.params.splitter == 'scaffold':
-        #    self.dataset = DiskDataset.from_numpy(features, self.vals, 
-        #                                          ids=dset_df[params.smiles_col].values)
-        #else:
-        #    self.dataset = DiskDataset.from_numpy(features, self.vals, ids=ids)
-        self.dataset = DiskDataset.from_numpy(features, self.vals, ids=ids)
+        self.dataset = NumpyDataset(features, self.vals, ids=ids)
 
     # ****************************************************************************************
     def save_featurized_data(self, featurized_dset_df):
@@ -866,11 +849,11 @@ class DatastoreDataset(ModelDataset):
 
             splitting (Splitting object): A splitting object created by the ModelDataset intiailization method
 
-            combined_train_valid_data (dc.DiskDataset): A dataset object (initialized as None), of the merged train and valid splits
+            combined_train_valid_data (dc.Dataset): A dataset object (initialized as None), of the merged train and valid splits
             ds_client (datastore client):
 
         set in get_featurized_data:
-            dataset: A new featurized DeepChem DiskDataset.
+            dataset: A new featurized DeepChem Dataset.
 
             n_features: The count of features (int)
 
@@ -1164,13 +1147,13 @@ class FileDataset(ModelDataset):
             
             splitting (Splitting object): A splitting object created by the ModelDataset intiailization method
             
-            combined_train_valid_data (dc.DiskDataset): A dataset object (initialized as None), of the merged train and
+            combined_train_valid_data (dc.Dataset): A dataset object (initialized as None), of the merged train and
             valid splits
             
             ds_client (datastore client):
 
         set in get_featurized_data:
-            dataset: A new featurized DeepChem DiskDataset.
+            dataset: A new featurized DeepChem Dataset.
             
             n_features: The count of features (int)
             


### PR DESCRIPTION
This branch replaces all uses of the deepchem DiskDataset class with NumpyDataset. There was never a good reason to use DiskDataset because the sizes of datasets we train models on were never big enough to benefit from sharding. In addition, the way we used DiskDataset (by calling the static from_numpy method) automatically put everything in one shard, so we've been dealing with the extra file I/O overhead without any gain. Using NumpyDataset should make model training and inference faster, and eliminate the temporary files that were generated every time the GMD loop made predictions from an AMPL model.

This branch also includes a fix to model_version_utils.get_ampl_version_from_model to read the model_metadata.json from a tarfile stream, without having to untar the model tarball first. This removes another source of excess temp files that was causing problems for the GMD loop.