### PR TITLE
Fix tutorial links

### DIFF
--- a/atomsci/ddm/examples/tutorials/AMPL_FNL_Wrshp2_1.ipynb
+++ b/atomsci/ddm/examples/tutorials/AMPL_FNL_Wrshp2_1.ipynb
@@ -38,7 +38,7 @@
    ],
    "source": [
     "from IPython.display import Image\n",
-    "Image(url='https://github.com/ATOMScience-org/AMPL/blob/master/atomsci/ddm/examples/tutorials/Img/ml-ready.png?raw=true')"
+    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/ml-ready.png?raw=true')"
    ]
   },
   {
@@ -128,7 +128,7 @@
    ],
    "source": [
     "# from IPython.display import Image\n",
-    "Image(url='https://github.com/ATOMScience-org/AMPL/blob/master/atomsci/ddm/examples/tutorials/Img/GCP-AMPL-FNL_Wrshp2-1-overview.png?raw=true')"
+    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/GCP-AMPL-FNL_Wrshp2-1-overview.png?raw=true')"
    ]
   },
   {

--- a/atomsci/ddm/examples/tutorials/AMPL_FNL_Wrshp2_1.ipynb
+++ b/atomsci/ddm/examples/tutorials/AMPL_FNL_Wrshp2_1.ipynb
@@ -38,7 +38,7 @@
    ],
    "source": [
     "from IPython.display import Image\n",
-    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/ml-ready.png?raw=true')"
+    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/ml-ready.png')"
    ]
   },
   {
@@ -128,7 +128,7 @@
    ],
    "source": [
     "# from IPython.display import Image\n",
-    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/GCP-AMPL-FNL_Wrshp2-1-overview.png?raw=true')"
+    "Image(url='https://raw.githubusercontent.com/ATOMScience-org/AMPL/master/atomsci/ddm/examples/tutorials/Img/GCP-AMPL-FNL_Wrshp2-1-overview.png')"
    ]
   },
   {

--- a/atomsci/ddm/examples/tutorials/README.md
+++ b/atomsci/ddm/examples/tutorials/README.md
@@ -72,7 +72,6 @@ This COLAB notebook will use AMPL for predicting binding affinities -pIC50 value
 
 This notebook also explores AMPL functions for saving and loading prebuild AMPL models for analysis. 
 * [Tutorial-12](12_AMPL_HPO_demo.ipynb) (**Time: ~ 30 minutes**) Hyper-parameter Optimization [(HPO)](https://en.wikipedia.org/wiki/Hyperparameter_optimization) and Uncertainty Quantification [(UQ)](https://en.wikipedia.org/wiki/Uncertainty_quantification).
-* [Tutorial-13](13_AMPL_HPO_Part2.ipynb) Notebook includes HPO Grid Search on three different modeling methods (Random Forest, NN and XGBoost) (*under preparation*)
 
 ## 4. Creating high-quality models 
 * Please refer to [08_AMPL_EDA_Part2.ipynb](08_AMPL_EDA_Part2.ipynb) and [09_AMPL_EDA_Part2_Classification.ipynb](09_AMPL_EDA_Part2_Classification.ipynb) that describe helpful hints for visualizing HPO results and methods to identify best performing models.


### PR DESCRIPTION
- [atomsci/ddm/examples/tutorials/README.md](https://github.com/ATOMScience-org/AMPL/compare/fix_tutorial_links?expand=1#diff-1a85e480e0db3d8fd21d99f26f37aa438ba9cd0f4650335c0e0fca3d5e009b70) 
   - removed tutorial 13(notebook doesn't exist)
 - [atomsci/ddm/examples/tutorials/AMPL_FNL_Wrshp2_1.ipynb](https://github.com/ATOMScience-org/AMPL/compare/fix_tutorial_links?expand=1#diff-82cdfd6a17e50c610a6ff07744c0f01b78d077cedb141f6d140a4aa949b94edd)
   - Updated the image links. For some reasons, two images in this notebook, show as invalid links from github. But from LC jupyter, the image links display fine. 