### PR TITLE
removed  --no-use-pep517 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ There are two install options.
 
 ```bash
 cd $AMPL_HOME/pip
-pip3 install --force-reinstall --no-use-pep517 -r clients_requirements.txt # install atomsci.clients
-pip3 install --force-reinstall --no-use-pep517 -r requirements.txt # install library packages
+pip3 install --force-reinstall -r clients_requirements.txt # install atomsci.clients
+pip3 install --force-reinstall -r requirements.txt # install library packages
 ```
 
   * For the external developers,

--- a/atomsci/ddm/docs/source/guide/install.rst
+++ b/atomsci/ddm/docs/source/guide/install.rst
@@ -47,7 +47,7 @@ Install with Docker
 * Get the Docker image and run it::
 
     docker pull paulsonak/atomsci-ampl
-    docker run -it -p 8888:8888 -v </local_workspace_folder>:</directory_in_docker> paulsonak/atomsci-ampl
+    docker run -it -p 8888:8888 -v </local_workspace_folder>:</directory_in_docker> atomsci/atomsci-ampl
     #inside docker environment
     jupyter-notebook --ip=0.0.0.0 --allow-root --port=8888 &
     # -OR-


### PR DESCRIPTION
Removed `--no-use-pep517` from README. Was removed from `1.6.0`. Since most users refer to the `master` branch, remove it till `1.6.0` is out.