### PR TITLE
Prefeat smiles check

### DIFF
--- a/atomsci/ddm/pipeline/diversity_plots.py
+++ b/atomsci/ddm/pipeline/diversity_plots.py
@@ -154,7 +154,7 @@ def plot_tani_dist_distr(df, smiles_col, df_name, radius=2, subset_col='subset',
             diststmp = pd.DataFrame(zip(diststmp,substmp), columns=['dist','subset'])
             dists=pd.concat([dists,diststmp])
     dists=dists.reset_index(drop=True)
-    fig, ax = plt.subplots(figsize=(plot_width, plot_width))
+    fig, ax = plt.subplots(1, figsize=(plot_width, plot_width), dpi=300)
     sns.kdeplot(data=dists[dists.subset!=ref_subset], x='dist', hue='subset', legend=True, common_norm=False, common_grid=True, fill=False, ax=ax)
     ax.set_xlabel('%s distance' % dist_metric)
     ax.set_ylabel('Density')
@@ -168,7 +168,7 @@ def plot_tani_dist_distr(df, smiles_col, df_name, radius=2, subset_col='subset',
 
 #------------------------------------------------------------------------------------------------------------------
 def diversity_plots(dset_key, datastore=True, bucket='public', title_prefix=None, ecfp_radius=4, umap_file=None, out_dir=None,
-                    id_col='compound_id', smiles_col='rdkit_smiles', is_base_smiles=False, response_col=None, max_for_mcs=300):
+                    id_col='compound_id', smiles_col='rdkit_smiles', is_base_smiles=False, response_col=None, max_for_mcs=300, colorpal=None):
     """
     Plot visualizations of diversity for an arbitrary table of compounds. At minimum, the file should contain
     columns for a compound ID and a SMILES string. Produces a clustered heatmap display of Tanimoto distances between
@@ -237,15 +237,16 @@ def diversity_plots(dset_key, datastore=True, bucket='public', title_prefix=None
     if response_col is not None:
         responses = cmpd_df[response_col].values
         uniq_responses = set(responses)
-        if uniq_responses == set([0,1]):
-            response_type = 'binary'
-            colorpal =  {0 : 'forestgreen', 1 : 'red'}
-        elif len(uniq_responses) <= 10:
-            response_type = 'categorical'
-            colorpal = sns.color_palette('husl', n_colors=len(uniq_responses))
-        else:
-            response_type = 'continuous'
-            colorpal = sns.blend_palette(['red', 'green', 'blue'], 12, as_cmap=True)
+        if colorpal is None:
+            if uniq_responses == set([0,1]):
+                response_type = 'binary'
+                colorpal =  {0 : 'forestgreen', 1 : 'red'}
+            elif len(uniq_responses) <= 10:
+                response_type = 'categorical'
+                colorpal = sns.color_palette('husl', n_colors=len(uniq_responses))
+            else:
+                response_type = 'continuous'
+                colorpal = sns.blend_palette(['red', 'green', 'blue'], 12, as_cmap=True)
 
 
 

--- a/atomsci/ddm/pipeline/featurization.py
+++ b/atomsci/ddm/pipeline/featurization.py
@@ -350,7 +350,7 @@ def compute_all_rdkit_descrs(mol_df, mol_col = "mol"):
     for mol in mol_df[mol_col]:
         cd = calc.CalcDescriptors(mol)
         cds.append(cd)
-    df2=pd.DataFrame(cds, columns=all_desc)
+    df2=pd.DataFrame(cds, columns=all_desc, index=mol_df.index)
     mol_df=mol_df.join(df2, lsuffix='', rsuffix='_rdk')
     return mol_df
     

--- a/atomsci/ddm/pipeline/featurization.py
+++ b/atomsci/ddm/pipeline/featurization.py
@@ -346,11 +346,14 @@ def compute_all_rdkit_descrs(mol_df, mol_col = "mol"):
     """
     all_desc = [x[0] for x in Descriptors._descList]
     calc = get_rdkit_calculator(all_desc)
-    for i in mol_df.index:
-        cd = calc.CalcDescriptors(mol_df.at[i, mol_col])
-        for desc, d in list(zip(all_desc, cd)):
-            mol_df.at[i, desc] = d
+    cds=[]
+    for mol in mol_df[mol_col]:
+        cd = calc.CalcDescriptors(mol)
+        cds.append(cd)
+    df2=pd.DataFrame(cds, columns=all_desc)
+    mol_df=mol_df.join(df2, lsuffix='', rsuffix='_rdk')
     return mol_df
+    
 
 def compute_rdkit_descriptors_from_smiles(smiles_strs, smiles_col='rdkit_smiles'):
     """

--- a/atomsci/ddm/pipeline/model_datasets.py
+++ b/atomsci/ddm/pipeline/model_datasets.py
@@ -1312,6 +1312,7 @@ class FileDataset(ModelDataset):
             self.dataset_key = self.params.dataset_key
             return dset_df
 
+
         # Otherwise, generate the expected path for the featurized dataset
         featurized_dset_name = self.featurization.get_featurized_dset_name(self.dataset_name)
         dataset_dir = os.path.dirname(self.params.dataset_key)
@@ -1320,6 +1321,13 @@ class FileDataset(ModelDataset):
         featurized_dset_df = pd.read_csv(featurized_dset_path)
         self.dataset_key = featurized_dset_path
         featurized_dset_df[self.params.id_col] = featurized_dset_df[self.params.id_col].astype(str)
+
+        # check if featurized dset has all the smiles from dset_df
+        dsetsmi=set(dset_df[self.params.smiles_col])
+        featsmi=set(featurized_dset_df[self.params.smiles_col])
+        if not dsetsmi-featsmi==set():
+            raise AssertionError("All of the smiles in your dataset are not represented in your featurization file. You can set previously_featurized to False and your featurized dataset will be overwritten to include the correct data.")
+
         return featurized_dset_df
 
     # ****************************************************************************************

--- a/atomsci/ddm/pipeline/model_datasets.py
+++ b/atomsci/ddm/pipeline/model_datasets.py
@@ -387,6 +387,8 @@ class ModelDataset(object):
                 self.dataset = NumpyDataset(features, self.vals, ids=ids, w=w)
                 self.log.info("Using prefeaturized data; number of features = " + str(self.n_features))
                 return
+            except AssertionError as a:
+                raise a
             except Exception as e:
                 self.log.debug("Exception when trying to load featurized data:\n%s" % str(e))
                 self.log.info("Featurized dataset not previously saved for dataset %s, creating new" % self.dataset_name)
@@ -1319,14 +1321,17 @@ class FileDataset(ModelDataset):
         data_dir = os.path.join(dataset_dir, self.featurization.get_featurized_data_subdir())
         featurized_dset_path = os.path.join(data_dir, featurized_dset_name)
         featurized_dset_df = pd.read_csv(featurized_dset_path)
-        self.dataset_key = featurized_dset_path
-        featurized_dset_df[self.params.id_col] = featurized_dset_df[self.params.id_col].astype(str)
 
         # check if featurized dset has all the smiles from dset_df
         dsetsmi=set(dset_df[self.params.smiles_col])
         featsmi=set(featurized_dset_df[self.params.smiles_col])
         if not dsetsmi-featsmi==set():
-            raise AssertionError("All of the smiles in your dataset are not represented in your featurization file. You can set previously_featurized to False and your featurized dataset will be overwritten to include the correct data.")
+            raise AssertionError("All of the smiles in your dataset are not represented in your featurized file. You can set previously_featurized to False and your featurized dataset located in the scaled_descriptors directory will be overwritten to include the correct data.")
+        
+        self.dataset_key = featurized_dset_path
+        featurized_dset_df[self.params.id_col] = featurized_dset_df[self.params.id_col].astype(str)
+
+        
 
         return featurized_dset_df
 

--- a/atomsci/ddm/utils/model_retrain.py
+++ b/atomsci/ddm/utils/model_retrain.py
@@ -88,7 +88,9 @@ def train_model(input, output, dskey='', production=False):
     params.production = production
     if params.production and 'nn_specific' in config:
         params.max_epochs = config['nn_specific']['best_epoch']+1
-
+    # change save mode if retraining elsewhere
+    if not mlmt_supported:
+        params.save_results=False
     # specify collection
     logger.debug("model params %s" % str(params))
     logger.debug(params.__dict__.items())

--- a/atomsci/ddm/utils/rdkit_easy.py
+++ b/atomsci/ddm/utils/rdkit_easy.py
@@ -73,11 +73,13 @@ def calculate_descriptors(df, molecule_column='mol'):
 
     descriptors = [x[0] for x in Descriptors._descList]
     calculator = MoleculeDescriptors.MolecularDescriptorCalculator(descriptors)
-    for i in df.index:
-        cd = calculator.CalcDescriptors(df.at[i, molecule_column])
-        for desc, d in list(zip(descriptors, cd)):
-            df.at[i, desc] = d
-
+    cds=[]
+    for mol in df[molecule_column]:
+        cd = calculator.CalcDescriptors(mol)
+        cds.append(cd)
+    df2=pd.DataFrame(cds, columns=descriptors)
+    df=df.join(df2, lsuffix='', rsuffix='_rdk')
+    return df
 
 def cluster_dataframe(df, molecule_column='mol', cluster_column='cluster', cutoff=0.2):
     """
@@ -112,7 +114,7 @@ def cluster_dataframe(df, molecule_column='mol', cluster_column='cluster', cutof
         for j in c:
             df_index = df2.at[j, 'df_index']
             df.at[df_index, cluster_column] = i
-
+    df=df.copy()
 
 def cluster_fingerprints(fps, cutoff=0.2):
     """


### PR DESCRIPTION
In this branch I did the following (sorry - I accidentally merged two branches before requesting pulls) 

4 commits in model_dataset.py from bug #237:
- create a check to see if all the smiles in a dataset are represented in the prefeaturized data
    - if not, raise assertion error
    - if so, allow
- raise the error up to get_featurized_data()

1 commit in diversity_plots.py: 
- I updated diversity_plots to allow a user-specified color palette and increase the resolution of the figure. No behavior will change unless you want to pass a color palette.

2 commits in featurization.py:
- reduce dataframe fragmentation by updating how the dataframe is constructed
- respect the original index of the file

1 commit in model_retrain.py:
- add a check so that if a model was originally trained and saved to the model tracker, it can be retrained and saved to the file system if the model tracker is unavailable (ie bringing a model tracker model outside LC)