### PR TITLE
defined .readthedocs.yaml for v2

### DIFF
--- a/atomsci/ddm/docs/.readthedocs.yaml
+++ b/atomsci/ddm/docs/.readthedocs.yaml
@@ -1,0 +1,37 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: atomsci/ddm/docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+   - pdf
+   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation. We recommend specifying your dependencies 
+# to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+install:
+   - requirements: pip/readthedocs_requirements.txt


### PR DESCRIPTION
Added  .readthedocs.yaml due to their changes:

> In line with [our deprecation plans for builds without a configuration file](https://blog.readthedocs.com/migrate-configuration-v2/), projects will be required to specify a configuration file to continue building their documentation starting September 25th.