### PR TITLE
Perf plots

### DIFF
--- a/atomsci/ddm/pipeline/perf_plots.py
+++ b/atomsci/ddm/pipeline/perf_plots.py
@@ -7,6 +7,9 @@ import os
 import matplotlib
 
 import sys
+import tempfile
+import tarfile
+import json
 import pandas as pd
 import numpy as np
 import seaborn as sns
@@ -16,7 +19,9 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from mpl_toolkits.mplot3d import Axes3D
 
+from atomsci.ddm.utils import file_utils as futils
 from atomsci.ddm.pipeline import perf_data as perf
+from atomsci.ddm.pipeline import predict_from_model as pfm
 
 #matplotlib.style.use('ggplot')
 matplotlib.rc('xtick', labelsize=12)
@@ -143,6 +148,113 @@ def plot_pred_vs_actual(MP, epoch_label='best', threshold=None, error_bars=False
     if pdf_dir is not None:
         pdf.close()
         MP.log.info("Wrote plot to %s" % pdf_path)
+
+
+#------------------------------------------------------------------------------------------------------------------------
+def plot_pred_vs_actual_from_df(pred_df, actual_col='avg_pIC50_actual', pred_col='avg_pIC50_pred', label='Prediction of Test Set', ax=None):
+    """
+    Plot predicted vs actual values from a trained regression model for a given dataframe.
+
+    Args:
+        pred_df (Pandas.DataFrame): A dataframe containing predicted and actual values for each compound.
+
+        actual_col (str): Column with actual values.
+
+        pred_col (str): Column with predicted values.
+
+        label (str): Descriptive label for the plot.
+
+        ax (matplotlib.axes.Axes): Optional, an axes object to plot onto. If None, one is created.
+
+    Returns:
+        g (matplotlib.axes.Axes): The axes object with data.
+
+    """
+    g=sns.scatterplot(x='avg_pIC50_actual', y='avg_pIC50_pred', data=pred_df, ax=ax)
+    lims = [
+        pred_df[[actual_col,pred_col]].min().min(),  # min of both axes
+        pred_df[[actual_col,pred_col]].max().max(),  # max of both axes
+    ]
+    margin=(lims[1]-lims[0])*0.05
+    lims=[lims[0]-margin,lims[1]+margin]
+    g.plot(lims, lims, 'r-', alpha=0.75, zorder=0)
+    # plt.gca().set_aspect('equal', adjustable='box')
+    g.set_aspect('equal')
+    g.set_xlim(lims)
+    g.set_ylim(lims)
+    g.set_title(label)
+    return g
+
+
+#------------------------------------------------------------------------------------------------------------------------
+def plot_pred_vs_actual_from_file(model_path):
+    """
+    Plot predicted vs actual values from a trained regression model from a model tarball.
+
+    Args:
+        model_path (str): Path to an AMPL model tar.gz file.
+
+    Returns:
+        None
+
+    Effects:
+        A matplotlib figure is displayed with subplots for each response column and train/valid/test subsets.
+
+    """
+    # reload model
+    reload_dir = tempfile.mkdtemp()
+    with tarfile.open(model_path, mode='r:gz') as tar:
+        futils.safe_extract(tar, path=reload_dir)
+    
+    # reload metadata
+    with open(os.path.join(reload_dir, 'model_metadata.json')) as f:
+        config=json.loads(f.read())
+    
+    # load (featurized) data
+    dataset_dict=config['training_dataset']
+    dataset_key=dataset_dict['dataset_key']
+    is_featurized=False
+    AD_method=None
+    if config['model_parameters']['featurizer'] in ['descriptors','computed_descriptors']:
+        desc=config['descriptor_specific']['descriptor_type']
+        dataset_key=dataset_key.rsplit('/', maxsplit=1)
+        dataset_key=os.path.join(dataset_key[0], 'scaled_descriptors', dataset_key[1].replace('.csv',f'_with_{desc}_descriptors.csv'))
+        is_featurized=True
+    if config['model_parameters']['featurizer'] != 'graphconv':
+        AD_method='z_score'
+    df=pd.read_csv(dataset_key)
+    
+    # reload split file
+    dataset_key=dataset_dict['dataset_key']
+    split_dict=config['splitting_parameters']
+    split_file=dataset_key.replace('.csv',f"_{split_dict['split_strategy']}_{split_dict['splitter']}_{split_dict['split_uuid']}.csv")
+    split=pd.read_csv(split_file)
+    split=split.rename(columns={'cmpd_id':dataset_dict['id_col']})
+    
+    # merge
+    df=df.merge(split, how='left')
+    
+    # get other values
+    response_cols=dataset_dict['response_cols']
+    
+    # run predictions
+    pred_df=pfm.predict_from_model_file(model_path, df, id_col=dataset_dict['id_col'], smiles_col=dataset_dict['smiles_col'], 
+                                        response_col=response_cols, is_featurized=is_featurized, AD_method=AD_method, dont_standardize=True)                              
+    
+    # plot
+    sns.set_context('notebook')
+    fig, ax = plt.subplots(len(response_cols),3,sharey=True,sharex=True,figsize=(10*len(response_cols),30))
+    if len(response_cols)>1:
+        for i,resp in enumerate(response_cols):
+            for j, subs in enumerate(['train','valid','test']):
+                tmp=pred_df[pred_df.subset==subs]
+                plot_pred_vs_actual_from_df(tmp, actual_col=f'{resp}_actual', pred_col=f'{resp}_pred', label=f'{resp} {subs}', ax=ax[i,j])
+    else:
+        resp=response_cols[0]
+        for j, subs in enumerate(['train','valid','test']):
+            tmp=pred_df[pred_df.subset==subs]
+            plot_pred_vs_actual_from_df(tmp, actual_col=f'{resp}_actual', pred_col=f'{resp}_pred', label=subs, ax=ax[j])
+    # fig.suptitle(f'Predicted vs Actual values for {resp} model', y=1.05)
 
 
 #------------------------------------------------------------------------------------------------------------------------

--- a/atomsci/ddm/utils/compare_splits_plots.py
+++ b/atomsci/ddm/utils/compare_splits_plots.py
@@ -93,6 +93,23 @@ class SplitStats:
         print("valid frac mean: %0.2f, median: %0.2f, std: %0.2f"%\
             (np.mean(self.valid_fracs), np.median(self.valid_fracs), np.std(self.valid_fracs)))
 
+    def dist_hist_train_v_test_plot(self, ax=None):
+        """
+        Plots Tanimoto differences between training and valid subsets
+
+        Returns:
+            g (Seaborn FacetGrid): FacetGrid object from seaborn
+        """
+        return self._show_dist_hist_plot(self.dists_tvt, ax=ax)
+
+    def dist_hist_train_v_valid_plot(self, ax=None):
+        """
+        Plots Tanimoto differences between training and valid subsets
+
+        Returns:
+            g (Seaborn FacetGrid): FacetGrid object from seaborn
+        """
+        return self._show_dist_hist_plot(self.dists_tvv, ax=ax)
 
     def dist_hist_plot(self, dists, title, dist_path=''):
         """
@@ -104,15 +121,30 @@ class SplitStats:
                 appended to this input
         """
         # plot compound distance histogram
-        pyplot.figure()
-        g = sns.distplot(dists, kde=False)
-        g.set_xlabel('Tanimoto Distance',fontsize=13)
-        g.set_ylabel('# Compound Pairs',fontsize=13)
-        g.set_title(title)
-        
+        fig=pyplot.figure()
+        g = self._show_dist_hist_plot(dists)
+        fig.suptitle(title)        
         if len(dist_path) > 0:
             save_figure(dist_path+'_dist_hist')
         pyplot.close()
+
+    def _show_dist_hist_plot(self, dists, ax=None):
+        """
+        Creates a histogram of pairwise Tanimoto distances between training
+        and test sets
+
+        Args:
+            dists (matrix): matrix of distances either self.dists_tvt or self.dists_tvv
+
+        Returns:
+            g (Seaborn FacetGrid): Plot object from seaborn
+
+        """
+        g=sns.histplot(dists, kde=False, stat='probability', ax=ax)
+        g.set_xlabel('Tanimoto Distance',fontsize=13)
+        g.set_ylabel('Proportion of Compounds',fontsize=13)
+
+        return g
 
     def umap_plot(self, dist_path=''):
         """


### PR DESCRIPTION
I updated 
- compare_splits tanimoto distance histograms to be matplotlib axes instead of seaborn facet grids
- perf_plots now have two more plots to plot predicted_vs_actual from a dataframe or from a model tarball
- still needs the comparable plots for classification models (#254)