### PR TITLE
Miscellaneous changes for 1.6.0

### DIFF
--- a/atomsci/ddm/pipeline/chem_diversity.py
+++ b/atomsci/ddm/pipeline/chem_diversity.py
@@ -12,7 +12,6 @@ from scipy.spatial.distance import squareform
 import pandas as pd
 import inspect
 
-from atomsci.ddm.utils import datastore_functions as dsf
 from atomsci.ddm.pipeline import dist_metrics
 
 def calc_dist_smiles(feat_type, dist_met, smiles_arr1, smiles_arr2=None, calc_type='nearest', num_nearest=1, **metric_kwargs):
@@ -246,6 +245,7 @@ def _get_descriptors(smiles_arr):
     """
     DEPRECATED. This function is guaranteed not to work, since it refers to datasets that no longer exist.
     """
+    from atomsci.ddm.utils import datastore_functions as dsf
     ds_client = dsf.config_client()
 
     full_feature_matrix_key = '/ds/projdata/gsk_data/GSK_datasets/eXP_Panel_Min_100_Cmpds/scaled_descriptors/' \
@@ -296,6 +296,7 @@ def upload_distmatrix_to_DS(
     Returns:
          None
     """
+    from atomsci.ddm.utils import datastore_functions as dsf
 
     dist_df = pd.DataFrame(dist_matrix)
     dist_df.index = compound_ids

--- a/atomsci/ddm/pipeline/compare_models.py
+++ b/atomsci/ddm/pipeline/compare_models.py
@@ -175,6 +175,11 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
     rf_max_depth_list = []
     xgb_learning_rate_list = []
     xgb_gamma_list = []
+    xgb_max_depth_list = []
+    xgb_colsample_bytree_list = []
+    xgb_subsample_list = []
+    xgb_n_estimators_list = []
+    xgb_min_child_weight_list = []
     best_epoch_list = []
     max_epochs_list = []
     subsets = ['train', 'valid', 'test']
@@ -223,6 +228,12 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
             rf_max_depth_list.append(nan)
             xgb_learning_rate_list.append(nan)
             xgb_gamma_list.append(nan)
+            xgb_max_depth_list.append(nan)
+            xgb_colsample_bytree_list.append(nan)
+            xgb_subsample_list.append(nan)
+            xgb_n_estimators_list.append(nan)
+            xgb_min_child_weight_list.append(nan)
+
         if model_type == 'RF':
             rf_params = metadata_dict['rf_specific']
             rf_estimators_list.append(rf_params['rf_estimators'])
@@ -235,6 +246,11 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
             dropouts_list.append(nan)
             xgb_learning_rate_list.append(nan)
             xgb_gamma_list.append(nan)
+            xgb_max_depth_list.append(nan)
+            xgb_colsample_bytree_list.append(nan)
+            xgb_subsample_list.append(nan)
+            xgb_n_estimators_list.append(nan)
+            xgb_min_child_weight_list.append(nan)
         if model_type == 'xgboost':
             xgb_params = metadata_dict['xgb_specific']
             rf_estimators_list.append(nan)
@@ -247,6 +263,11 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
             dropouts_list.append(nan)
             xgb_learning_rate_list.append(xgb_params["xgb_learning_rate"])
             xgb_gamma_list.append(xgb_params["xgb_gamma"])
+            xgb_max_depth_list.append(xgb_params["xgb_max_depth"])
+            xgb_colsample_bytree_list.append(xgb_params["xgb_colsample_bytree"])
+            xgb_subsample_list.append(xgb_params["xgb_subsample"])
+            xgb_n_estimators_list.append(xgb_params["xgb_n_estimators"])
+            xgb_min_child_weight_list.append(xgb_params["xgb_min_child_weight"])
         for subset in subsets:
             score_dict[subset].append(subset_metrics[subset][metric_type])
 
@@ -265,7 +286,12 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
                     rf_max_features=rf_max_features_list,
                     rf_max_depth=rf_max_depth_list,
                     xgb_learning_rate = xgb_learning_rate_list,
-                    xgb_gamma = xgb_gamma_list))
+                    xgb_gamma = xgb_gamma_list,
+                    xgb_max_depth = xgb_max_depth_list,
+                    xgb_colsample_bytree = xgb_colsample_bytree_list,
+                    xgb_subsample = xgb_subsample_list,
+                    xgb_n_estimators = xgb_n_estimators_list,
+                    xgb_min_child_weight = xgb_min_child_weight_list))
     for subset in subsets:
         metric_col = '%s_%s' % (metric_type, subset)
         perf_df[metric_col] = score_dict[subset]
@@ -277,7 +303,7 @@ def get_training_perf_table(dataset_key, bucket, collection_name, pred_type='reg
 # -----------------------------------------------------------------------------------------------------------------
 def extract_model_and_feature_parameters(metadata_dict):
     """
-    Given a config file, extract model and featuer parameters. Looks for parameter names
+    Given a config file, extract model and featurizer parameters. Looks for parameter names
     that end in *_specific. e.g. nn_specific, auto_featurizer_specific
 
     Args:
@@ -285,14 +311,17 @@ def extract_model_and_feature_parameters(metadata_dict):
 
     Returns:
         dictionary containing featurizer and model parameters. Most contain the following
-        keys. ['max_epochs', 'best_epoch', 'learning_rate', 'layer_sizes', 'drop_outs', 
+        keys. ['max_epochs', 'best_epoch', 'learning_rate', 'layer_sizes', 'dropouts', 
         'rf_estimators', 'rf_max_features', 'rf_max_depth', 'xgb_gamma', 'xgb_learning_rate',
+        'xgb_max_depth', 'xgb_colsample_bytree', 'xgb_subsample', 'xgb_n_estimators', 'xgb_min_child_weight',
         'featurizer_parameters_dict', 'model_parameters_dict']
     """
     model_params = metadata_dict['model_parameters']
     model_type = model_params['model_type']
     required = ['max_epochs', 'best_epoch', 'learning_rate', 'layer_sizes', 'dropouts', 
-        'rf_estimators', 'rf_max_features', 'rf_max_depth', 'xgb_gamma', 'xgb_learning_rate']
+        'rf_estimators', 'rf_max_features', 'rf_max_depth', 'xgb_gamma', 'xgb_learning_rate',
+        'xgb_max_depth', 'xgb_colsample_bytree', 'xgb_subsample', 'xgb_n_estimators', 'xgb_min_child_weight'
+        ]
 
     model_info = {}
     model_info['model_uuid'] = metadata_dict['model_uuid']
@@ -312,6 +341,11 @@ def extract_model_and_feature_parameters(metadata_dict):
         xgb_params = metadata_dict['xgb_specific']
         model_info['xgb_gamma'] = xgb_params['xgb_gamma']
         model_info['xgb_learning_rate'] = xgb_params['xgb_learning_rate']
+        model_info['xgb_max_depth'] = xgb_params['xgb_max_depth']
+        model_info['xgb_colsample_bytree'] = xgb_params['xgb_colsample_bytree']
+        model_info['xgb_subsample'] = xgb_params['xgb_subsample']
+        model_info['xgb_n_estimators'] = xgb_params['xgb_n_estimators']
+        model_info['xgb_min_child_weight'] = xgb_params['xgb_min_child_weight']
 
     for r in required:
         if r not in model_info:
@@ -335,10 +369,6 @@ def extract_model_and_feature_parameters(metadata_dict):
         model_metadata = metadata_dict['rf_specific']
     elif 'xgb_specific' in metadata_dict:
         model_metadata = metadata_dict['xgb_specific']
-        # delete several parameters that aren't normally saved
-        ignored_params = ['xgb_colsample_bytree','xgb_max_depth',
-            'xgb_min_child_weight','xgb_n_estimators','xgb_subsample']
-        del_ignored_params(model_metadata, ignored_params)
     else:
         # no model parameters found
         model_metadata = {}
@@ -1443,8 +1473,13 @@ def get_summary_metadata_table(uuids, collections=None):
                          'Transformation': transform,
                          'AMPL version used:': mdl_params.get('ampl_version', 'probably 1.0.0'),
                          'Model Type (Featurizer)':    '%s (%s)' % (mdl_params['model_type'],featurizer),
+                         'XGB learning rate': xgb_params['xgb_learning_rate'],
                          'Gamma':    xgb_params['xgb_gamma'],
-                         'Learning rate': xgb_params['xgb_max_depth'],
+                         'XGB max depth': xgb_params['xgb_max_depth'],
+                         'Column sample fraction':    xgb_params['xgb_colsample_bytree'],
+                         'Row subsample fraction':    xgb_params['xgb_subsample'],
+                         'Number of estimators':    xgb_params['xgb_n_estimators'],
+                         'Minimum child weight':    xgb_params['xgb_min_child_weight'],
                          'r^2 (Train/Valid/Test)':       '%0.2f/%0.2f/%0.2f' % (train_metrics['r2_score'], valid_metrics['r2_score'], test_metrics['r2_score']),
                          'MAE (Train/Valid/Test)':       '%0.2f/%0.2f/%0.2f' % (train_metrics['mae_score'], valid_metrics['mae_score'], test_metrics['mae_score']),
                          'RMSE(Train/Valid/Test)':       '%0.2f/%0.2f/%0.2f' % (train_metrics['rms_score'], valid_metrics['rms_score'], test_metrics['rms_score']),
@@ -1517,8 +1552,13 @@ def get_summary_metadata_table(uuids, collections=None):
                          'Transformation': transform,
                          'AMPL version used:': mdl_params.get('ampl_version', 'probably 1.0.0'),
                          'Model Type (Featurizer)':    '%s (%s)' % (mdl_params['model_type'],featurizer),
+                         'XGB learning rate': xgb_params['xgb_learning_rate'],
                          'Gamma':    xgb_params['xgb_gamma'],
-                         'XGB Learning rate': xgb_params['xgb_max_depth'],
+                         'XGB max depth': xgb_params['xgb_max_depth'],
+                         'Column sample fraction':    xgb_params['xgb_colsample_bytree'],
+                         'Row subsample fraction':    xgb_params['xgb_subsample'],
+                         'Number of estimators':    xgb_params['xgb_n_estimators'],
+                         'Minimum child weight':    xgb_params['xgb_min_child_weight'],
                          'ROC AUC (Train/Valid/Test)':     '%0.2f/%0.2f/%0.2f' % (train_metrics['roc_auc_score'], valid_metrics['roc_auc_score'], test_metrics['roc_auc_score']),
                          'PRC AUC (Train/Valid/Test)':     '%0.2f/%0.2f/%0.2f' % (train_metrics['prc_auc_score'], valid_metrics['prc_auc_score'], test_metrics['prc_auc_score']),
                          'Balanced accuracy (Train/Valid/Test)':     '%0.2f/%0.2f/%0.2f' % (train_metrics.get('bal_accuracy', np.nan), valid_metrics.get('bal_accuracy',np.nan), test_metrics.get('bal_accuracy', np.nan)),
@@ -2021,7 +2061,9 @@ def get_multitask_perf_from_tracker(collection_name, response_cols=None, expand_
                   'weight_decay_penalty', 'weight_decay_penalty_type', 'weight_init_stddevs', 'splitter',
                   'split_uuid', 'split_test_frac', 'split_valid_frac', 'smiles_col', 'id_col',
                   'feature_transform_type', 'response_cols', 'response_transform_type', 'num_model_tasks',
-                  'rf_estimators', 'rf_max_depth', 'rf_max_features', 'xgb_gamma', 'xgb_learning_rate']
+                  'rf_estimators', 'rf_max_depth', 'rf_max_features', 'xgb_gamma', 'xgb_learning_rate',
+                  'xgb_max_depth', 'xgb_colsample_bytree', 'xgb_subsample', 'xgb_n_estimators', 'xgb_min_child_weight',
+                  ]
         keepcols.extend(alldat.columns[alldat.columns.str.contains('best')])
         keepcols = list(set(alldat.columns).intersection(keepcols))
         keepcols.sort()

--- a/atomsci/ddm/pipeline/compare_models.py
+++ b/atomsci/ddm/pipeline/compare_models.py
@@ -910,6 +910,7 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
     featurizer_list = []
     dataset_key_list = []
     splitter_list = []
+    split_strategy_list = []
     model_score_type_list = []
     feature_transform_type_list = []
 
@@ -993,6 +994,7 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
         featurizer_list.append(featurizer)
         split_params = metadata_dict['splitting_parameters']
         splitter_list.append(split_params['splitter'])
+        split_strategy_list.append(split_params['split_strategy'])
         dataset_key_list.append(metadata_dict['training_dataset']['dataset_key'])
         feature_transform_type = metadata_dict['training_dataset']['feature_transform_type']
         feature_transform_type_list.append(feature_transform_type)
@@ -1016,6 +1018,7 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
                     dataset_key=dataset_key_list,
                     features=featurizer_list,
                     splitter=splitter_list,
+                    split_strategy=split_strategy_list,
                     model_score_type=model_score_type_list,
                     feature_transform_type=feature_transform_type_list))
 

--- a/atomsci/ddm/pipeline/featurization.py
+++ b/atomsci/ddm/pipeline/featurization.py
@@ -761,7 +761,7 @@ class DynamicFeaturization(Featurization):
             feat_df = pd.DataFrame(dict(c0=features))
         featurized_dset_df = pd.concat([keep_df, feat_df], ignore_index=False, axis=1)
 
-        if contains_responses:
+        if contains_responses and (params.model_type != 'hybrid'):
             vals, w = make_weights(featurized_dset_df[params.response_cols].values) #, self.id_field)
         else:
             vals = np.zeros((nrows,ncols))
@@ -1484,7 +1484,7 @@ class DescriptorFeaturization(PersistentFeaturization):
 
         nrows = len(ids)
         ncols = len(params.response_cols)
-        if contains_responses:
+        if contains_responses and (params.model_type != 'hybrid'):
             vals = featurized_dset_df[params.response_cols].values
             vals, weights = make_weights(vals)
         else:
@@ -1781,7 +1781,7 @@ class ComputedDescriptorFeaturization(DescriptorFeaturization):
         ids = featurized_dset_df[params.id_col]
         nrows = len(ids)
         ncols = len(params.response_cols)
-        if contains_responses:
+        if contains_responses and (params.model_type != 'hybrid'):
             vals = featurized_dset_df[params.response_cols].values
             vals, weights = make_weights(vals)
         else:

--- a/atomsci/ddm/pipeline/parameter_parser.py
+++ b/atomsci/ddm/pipeline/parameter_parser.py
@@ -1536,6 +1536,21 @@ def get_parser():
     parser.add_argument(
         '--xgbl', dest='xgbl', required=False, default=None,
         help='xgb_learning_rate shown in HyperOpt domain format, e.g. --xgbl=loguniform|-6.9,-2.3')
+    parser.add_argument(
+        '--xgbd', dest='xgbd', required=False, default=None,
+        help='xgb_max_depth shown in HyperOpt domain format, e.g. --xgbd=uniformint|3,10')
+    parser.add_argument(
+        '--xgbc', dest='xgbc', required=False, default=None,
+        help='xgb_colsample_bytree shown in HyperOpt domain format, e.g. --xgbc=uniform|0.1,1.0')
+    parser.add_argument(
+        '--xgbs', dest='xgbs', required=False, default=None,
+        help='xgb_subsample shown in HyperOpt domain format, e.g. --xgbs=uniform|0.1,1.0')
+    parser.add_argument(
+        '--xgbn', dest='xgbn', required=False, default=None,
+        help='xgb_n_estimators shown in HyperOpt domain format, e.g. --xgbn=choice|200,500,1000')
+    parser.add_argument(
+        '--xgbw', dest='xgbw', required=False, default=None,
+        help='xgb_min_child_weight shown in HyperOpt domain format, e.g. --xgbw=uniform|1.0,1.2')
     # checkpoint
     parser.add_argument(
         '--hp_checkpoint_save', dest='hp_checkpoint_save', required=False, default=None,

--- a/atomsci/ddm/utils/hyperparam_search_wrapper.py
+++ b/atomsci/ddm/utils/hyperparam_search_wrapper.py
@@ -1479,6 +1479,36 @@ class HyperOptSearch():
                 par_list = [float(e) for e in domain_list[1].split(",")]
                 self.space["xgbl"] = build_hyperopt_search_domain("xgbl", method, par_list)
 
+            if self.params.xgbd:
+                domain_list = self.params.xgbd.split("|")
+                method = domain_list[0]
+                par_list = [float(e) for e in domain_list[1].split(",")]
+                self.space["xgbd"] = build_hyperopt_search_domain("xgbd", method, par_list)
+
+            if self.params.xgbc:
+                domain_list = self.params.xgbc.split("|")
+                method = domain_list[0]
+                par_list = [float(e) for e in domain_list[1].split(",")]
+                self.space["xgbc"] = build_hyperopt_search_domain("xgbc", method, par_list)
+
+            if self.params.xgbs:
+                domain_list = self.params.xgbs.split("|")
+                method = domain_list[0]
+                par_list = [float(e) for e in domain_list[1].split(",")]
+                self.space["xgbs"] = build_hyperopt_search_domain("xgbs", method, par_list)
+
+            if self.params.xgbn:
+                domain_list = self.params.xgbn.split("|")
+                method = domain_list[0]
+                par_list = [float(e) for e in domain_list[1].split(",")]
+                self.space["xgbn"] = build_hyperopt_search_domain("xgbn", method, par_list)
+
+            if self.params.xgbw:
+                domain_list = self.params.xgbw.split("|")
+                method = domain_list[0]
+                par_list = [float(e) for e in domain_list[1].split(",")]
+                self.space["xgbw"] = build_hyperopt_search_domain("xgbw", method, par_list)
+
 
     def run_search(self):
         #name of the results
@@ -1525,8 +1555,24 @@ class HyperOptSearch():
                     self.params.xgb_gamma = p["xgbg"]
                 if self.params.xgbl:
                     self.params.xgb_learning_rate = p["xgbl"]
-                hp_params = f'{self.params.xgb_gamma}_{self.params.xgb_learning_rate}'
-                print(f"xgb_gamma: {self.params.xgb_gamma}, xgb_learing_rate: {self.params.xgb_learning_rate}")
+                if self.params.xgbd:
+                    self.params.xgb_max_depth = p["xgbd"]
+                if self.params.xgbc:
+                    self.params.xgb_colsample_bytree = p["xgbc"]
+                if self.params.xgbs:
+                    self.params.xgb_subsample = p["xgbs"]
+                if self.params.xgbn:
+                    self.params.xgb_n_estimators = p["xgbn"]
+                if self.params.xgbw:
+                    self.params.xgb_min_child_weight = p["xgbw"]
+                hp_params = f'{self.params.xgb_gamma}_{self.params.xgb_learning_rate}_{self.params.xgb_max_depth}_{self.params.xgb_colsample_bytree}_{self.params.xgb_subsample}_{self.params.xgb_n_estimators}_{self.params.xgb_min_child_weight}'
+                print(f"xgb_gamma: {self.params.xgb_gamma}, "
+                      f"xgb_learning_rate: {self.params.xgb_learning_rate}, "
+                      f"xgb_max_depth: {self.params.xgb_max_depth}, "
+                      f"xgb_colsample_bytree: {self.params.xgb_colsample_bytree}, "
+                      f"xgb_subsample: {self.params.xgb_subsample}, "
+                      f"xgb_n_estimators: {self.params.xgb_n_estimators}, "
+                      f"xgb_min_child_weight: {self.params.xgb_min_child_weight}")
 
             # set hyperparam to False to make sure the layer_sizes and dropouts are not lists if not optimized.
             self.params.hyperparam = False
@@ -1703,7 +1749,7 @@ def parse_params(param_list):
                    'slurm_time_limit'} | excluded_keys
     if params.search_type == 'hyperopt':
         # keep more parameters
-        keep_params = keep_params | {'lr', 'learning_rate','ls', 'layer_sizes','ls_ratio','dp', 'dropouts','rfe', 'rf_estimators','rfd', 'rf_max_depth','rff', 'rf_max_features','xgbg', 'xgb_gamma','xgbl', 'xgb_learning_rate', 'hp_checkpoint_load', 'hp_checkpoint_save'}
+        keep_params = keep_params | {'lr', 'learning_rate','ls', 'layer_sizes','ls_ratio','dp', 'dropouts','rfe', 'rf_estimators','rfd', 'rf_max_depth','rff', 'rf_max_features','xgbg', 'xgb_gamma','xgbl', 'xgb_learning_rate', 'xgbd', 'xgb_max_depth', 'xgbc', 'xgb_colsample_bytree', 'xgbs', 'xgb_subsample', 'xgbn', 'xgb_n_estimators', 'xgbw', 'xgb_min_child_weight', 'hp_checkpoint_load', 'hp_checkpoint_save'}
 
     params.__dict__ = parse.prune_defaults(params, keep_params=keep_params)
 

--- a/atomsci/ddm/utils/patch_model_dataset_key.py
+++ b/atomsci/ddm/utils/patch_model_dataset_key.py
@@ -100,6 +100,11 @@ def patch_model_dataset_key(model_path, new_model_path, dataset_path, require_ha
         # TODO: Check that it's OK to leave the original dataset_key and hash in the various training_metrics
         # elements.
 
+        # Write the modified metadata.json file
+        with open(meta_path, 'w') as meta_fp:
+            json.dump(meta_dict, meta_fp, sort_keys=True, indent=4, separators=(',', ': '))
+            meta_fp.write("\n")
+
         # Create the new tarball
         os.makedirs(os.path.dirname(new_model_path), exist_ok=True)
         with tarfile.open(new_model_path, mode='w:gz') as tarball:

--- a/atomsci/ddm/utils/patch_model_dataset_key.py
+++ b/atomsci/ddm/utils/patch_model_dataset_key.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+"""
+Script to create a new version of a model tarball file with the training dataset dataset_key
+parameter (in model_metadata.json) pointing to a different file path. This may be needed when the
+model was trained on a different computer system or with data in a private directory, and the model
+is subsequently made publicly available. In this case the training data needs to be copied to an
+accessible directory on the target computer so that it can be used for AD index computations when
+predicting from the model.
+"""
+
+import os
+import sys
+import tarfile
+import tempfile
+import json
+import glob
+
+from atomsci.ddm.utils import checksum_utils as cu
+from atomsci.ddm.utils import file_utils as futils
+
+def check_data_accessibility(model_path, verbose=True):
+    """
+    Check the dataset_key parameters in one or more AMPL model tarball files 
+    to see if the associated dataset files are readable. If `model_path` is a directory, the files
+    within it with .tar.gz extensions are checked; otherwise it is interpreted as a path to a model
+    tarball. Returns a dictionary with tarball paths as keys and tuples as values, with the first
+    element of the tuple being the training dataset path and the second a boolean indicating whether
+    it is readable.
+    """
+    if os.path.isdir(model_path):
+        model_paths = glob.glob(f"{model_path}/*.tar.gz")
+    else:
+        model_paths = [model_path]
+    dataset_info = {}
+    for path in model_paths:
+        with tarfile.open(path, mode='r:gz') as tarball:
+            try:
+                meta_info = tarball.getmember('./model_metadata.json')
+            except KeyError:
+                print(f"{path} is not an AMPL model tarball")
+                continue
+            with tarball.extractfile(meta_info) as meta_fd:
+                meta_dict = json.loads(meta_fd.read())
+                dataset_path = meta_dict['training_dataset']['dataset_key']
+                try:
+                    dset_fp = open(dataset_path, 'r')
+                    dset_fp.close()
+                    dataset_info[path] = (dataset_path, True)
+                except:
+                    dataset_info[path] = (dataset_path, False)
+                    if verbose:
+                        print(f"{os.path.basename(path)} trained on unreadable file:\n\t{dataset_path}")
+    return dataset_info
+
+
+def patch_model_dataset_key(model_path, new_model_path, dataset_path, require_hash_match=True):
+    """
+    Create a new version of the model tarball given by `model_path` with its dataset_key parameter
+    replaced with `dataset_path`, and write it to `new_model_path`.
+
+    Args:
+        model_path (str): Path to existing model tarball.
+
+        new_model_path (str): Path to write new model to.
+
+        dataset_path (str): New path for training dataset.
+
+        require_hash_match (bool): If True, do not create a new tarball if the checksum for the file 
+        at `dataset_path` doesn't match the checksum stored in the model metadata.
+    """
+
+    # Compute a checksum for the new dataset.
+    try:
+        new_hash = cu.create_checksum(dataset_path)
+    except Exception as e:
+        print(f"Error reading dataset {dataset_path}")
+        raise
+
+    # Extract the model tarball into a temporary directory
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with open(model_path, 'rb') as tarfile_fp:
+            with tarfile.open(fileobj=tarfile_fp, mode='r:gz') as tfile:
+                tar_contents = tfile.getnames()
+                if not './model_metadata.json' in tar_contents:
+                    raise ValueError(f"{model_path} is not an AMPL model tarball")
+                futils.safe_extract(tfile, path=tmp_dir)
+        meta_path = os.path.join(tmp_dir, 'model_metadata.json')
+        with open(meta_path, 'r') as meta_fp:
+            meta_dict = json.load(meta_fp)
+        old_hash = meta_dict['training_dataset']['dataset_hash']
+        if new_hash != old_hash:
+            print(f"Warning: {dataset_path} is different from the original model training dataset at:")
+            print(meta_dict['training_dataset']['dataset_key'])
+            if require_hash_match:
+                print('New model tarball not created')
+                return 1
+            meta_dict['training_dataset']['dataset_hash'] = new_hash
+        meta_dict['training_dataset']['dataset_key'] = os.path.realpath(dataset_path)
+        # TODO: Check that it's OK to leave the original dataset_key and hash in the various training_metrics
+        # elements.
+
+        # Create the new tarball
+        os.makedirs(os.path.dirname(new_model_path), exist_ok=True)
+        with tarfile.open(new_model_path, mode='w:gz') as tarball:
+            tarball.add(tmp_dir, arcname='.')
+            print(f"Wrote {new_model_path}")
+        return 0
+
+if (__file__ == '__main__') and (len(sys.argv) > 3):
+    model_path = sys.argv[1]
+    new_model_path = sys.argv[2]
+    dataset_path = sys.argv[3]
+    require_hash_match = True
+    if len(sys.argv) > 4:
+        require_hash_match = (sys.argv[4].lower().startswith('n'))
+    retval = patch_model_dataset_key(model_path, new_model_path, dataset_path, require_hash_match)
+    sys.exit(retval)
+
+

--- a/atomsci/ddm/utils/rdkit_easy.py
+++ b/atomsci/ddm/utils/rdkit_easy.py
@@ -175,8 +175,12 @@ def mol_to_html(mol, highlight=None, name='', type='svg', directory='rdkit_svg',
     
     if type.lower() not in ['png','svg']:
         log.warning('Image type not recognized. Choose between png and svg.')
-        return
+        return ''
     
+    # Handle Mol generated from invalid SMILES string
+    if mol is None:
+        return ''
+
     if embed:
         if type.lower() == 'png':
             img=mol_to_pil(mol, size=(width,height), highlight=highlight)


### PR DESCRIPTION
- Add full support for all XGBoost model parameters, including hyperopt searches.
- Add split_strategy output column to compare_models.get_filesystem_perf_results.
- Fix bug in setting response column weights to make it consistent across featurizers.
- Fix error handling in rdkit_easy.mol_to_html to return empty string rather than None.
- Only import datastore_functions module in functions that require it, so that atomsci-clients isn't required.
- Add script for patching model tarballs to point to local copy of training data (needed for AD computation).