### PR TITLE
Weight transform akp

### DIFF
--- a/atomsci/ddm/pipeline/compare_models.py
+++ b/atomsci/ddm/pipeline/compare_models.py
@@ -929,8 +929,10 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
     dataset_key_list = []
     splitter_list = []
     split_strategy_list = []
+    split_uuid_list = []
     model_score_type_list = []
     feature_transform_type_list = []
+    weight_transform_type_list = []
 
     # model type specific lists
     param_list = []
@@ -1013,11 +1015,16 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
         split_params = metadata_dict['splitting_parameters']
         splitter_list.append(split_params['splitter'])
         split_strategy_list.append(split_params['split_strategy'])
+        split_uuid_list.append(split_params['split_uuid'])
         dataset_key_list.append(metadata_dict['training_dataset']['dataset_key'])
         feature_transform_type = metadata_dict['training_dataset']['feature_transform_type']
         feature_transform_type_list.append(feature_transform_type)
+        try:
+            weight_transform_type_list.append(metadata_dict['training_dataset']['weight_transform_type'])
+        except:
+            weight_transform_type_list.append(None)
 
-        param_list.append(extract_model_and_feature_parameters(metadata_dict))
+        param_list.append(extract_model_and_feature_parameters(metadata_dict, keep_required=expand))
 
         for subset in subsets:
             for metric in metrics:
@@ -1037,8 +1044,10 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
                     features=featurizer_list,
                     splitter=splitter_list,
                     split_strategy=split_strategy_list,
+                    split_uuid=split_uuid_list,
                     model_score_type=model_score_type_list,
-                    feature_transform_type=feature_transform_type_list))
+                    feature_transform_type=feature_transform_type_list,
+                    weight_transform_type=weight_transform_type_list))
 
     perf_df['model_choice_score'] = score_dict['valid']['model_choice_score']
     for subset in subsets:
@@ -1049,8 +1058,9 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
     sort_by = 'model_choice_score'
     perf_df = perf_df.sort_values(sort_by, ascending=False)
     
-    logger.warn('Warning: column names have been changed to align with get_multitask_perf_from_tracker(): featurizer is now features and <subset>_<metric> has been changed to best_<subset>_<metric>.')
+    logger.info('Warning: column names have been changed to align with get_multitask_perf_from_tracker(): featurizer is now features and <subset>_<metric> has been changed to best_<subset>_<metric>.')
     return perf_df
+
 
 def get_filesystem_models(result_dir, pred_type):
 

--- a/atomsci/ddm/pipeline/compare_models.py
+++ b/atomsci/ddm/pipeline/compare_models.py
@@ -1058,7 +1058,6 @@ def get_filesystem_perf_results(result_dir, pred_type='classification'):
     sort_by = 'model_choice_score'
     perf_df = perf_df.sort_values(sort_by, ascending=False)
     
-    logger.info('Warning: column names have been changed to align with get_multitask_perf_from_tracker(): featurizer is now features and <subset>_<metric> has been changed to best_<subset>_<metric>.')
     return perf_df
 
 

--- a/atomsci/ddm/pipeline/model_pipeline.py
+++ b/atomsci/ddm/pipeline/model_pipeline.py
@@ -316,6 +316,7 @@ class ModelPipeline:
             response_cols=self.params.response_cols,
             feature_transform_type=self.params.feature_transform_type,
             response_transform_type=self.params.response_transform_type,
+            weight_transform_type=self.params.weight_transform_type,
             external_export_parameters=dict(
                 result_dir=self.params.result_dir),
             dataset_metadata=dataset_metadata,

--- a/atomsci/ddm/pipeline/parameter_parser.py
+++ b/atomsci/ddm/pipeline/parameter_parser.py
@@ -1263,7 +1263,7 @@ def get_parser():
         '--response_transform_type', dest='response_transform_type', default='normalization',
         help='type of normalization for the response column TODO: Not currently implemented')
     parser.add_argument(
-        '--weight_transform_type', dest='weight_transform_type', choices=['balancing'], default=None,
+        '--weight_transform_type', dest='weight_transform_type', choices=[None, 'None', 'balancing'], default=None,
         help='type of normalization for the weights')
     parser.add_argument(
         '--transformer_bucket', dest='transformer_bucket', default=None,


### PR DESCRIPTION
I fleshed out the capabilities of ampl to handle the `balancing` weights transformer by including the information in the `model_metadata` (in the training dataset part along with `feature_transform_type`), and including `weight_transform_type` (along with `split_uuid`) in the `compare_models.get_filesystem_perf_results()` dataframe. 

After doing this, I also had to expand the parameter parser to accept `None` and `'None'` as options for the `weight_transform_type` because previously the only option in the list was `'balancing'` and this threw errors when trying to predict from a model with 'None' transform type (I'm not sure where the string None came from).

I can still get through all the tutorials without errors so I think this is OK to merge but would like a second pair of eyes!