### PR TITLE
fix make_weights to correctly change strings to nans while keeping cl…

### DIFF
--- a/atomsci/ddm/pipeline/featurization.py
+++ b/atomsci/ddm/pipeline/featurization.py
@@ -70,17 +70,18 @@ def make_weights(vals, is_class=False):
         vals: numpy array same as input vals, but strings are replaced with 0 (for classification models) or nans (for regression models)
         w: numpy array same shape as out_vals, where w[i,j] = 1 if vals[i,j] is nan else w[i,j] = 0
     """
+    out_vals = np.copy(vals)
     # sometimes instead of nan, '' is used for missing values
-    if not np.issubdtype(vals.dtype, np.number):
+    if not np.issubdtype(out_vals.dtype, np.number):
         # there might be strings or other objects in this array
-        vals[vals==''] = np.nan
-    vals = vals.astype(float)
-    w = np.where(np.isnan(vals), 0., 1).astype(float)
+        out_vals[out_vals==''] = np.nan
+    out_vals = out_vals.astype(float)
+    w = np.where(np.isnan(out_vals), 0., 1).astype(float)
     if is_class:
-        vals = np.where(np.isnan(vals), 0., vals)
-        return vals, w
+        out_vals = np.where(np.isnan(out_vals), 0., out_vals)
+        return out_vals, w
     else:
-        return vals, w
+        return out_vals, w
 
 
 # ****************************************************************************************

--- a/atomsci/ddm/pipeline/featurization.py
+++ b/atomsci/ddm/pipeline/featurization.py
@@ -64,22 +64,21 @@ def make_weights(vals, is_class=False):
     it with 0 if there is not value or 1 if there is.
 
     Args:
-        vals: numpy array containing nans where there are not labels
+        vals: numpy array containing nans or empty strings where there are not labels
 
     Returns:
-        out_vals: numpy array same as input vals, but nans are replaced with 0
-        w: numpy array same shape as vals, where w[i,j] = 1 if vals[i,j] is nan else w[i,j] = 0
+        vals: numpy array same as input vals, but strings are replaced with 0 (for classification models) or nans (for regression models)
+        w: numpy array same shape as out_vals, where w[i,j] = 1 if vals[i,j] is nan else w[i,j] = 0
     """
     # sometimes instead of nan, '' is used for missing values
-    out_vals = np.copy(vals)
-    if not np.issubdtype(out_vals.dtype, np.number):
+    if not np.issubdtype(vals.dtype, np.number):
         # there might be strings or other objects in this array
-        out_vals[out_vals==''] = np.nan
-    out_vals = out_vals.astype(float)
-    w = np.where(np.isnan(out_vals), 0., 1).astype(float)
-    out_vals = np.where(np.isnan(out_vals), 0., out_vals)
+        vals[vals==''] = np.nan
+    vals = vals.astype(float)
+    w = np.where(np.isnan(vals), 0., 1).astype(float)
     if is_class:
-        return out_vals, w
+        vals = np.where(np.isnan(vals), 0., vals)
+        return vals, w
     else:
         return vals, w
 

--- a/atomsci/ddm/test/unit/test_make_weights.py
+++ b/atomsci/ddm/test/unit/test_make_weights.py
@@ -8,6 +8,14 @@ correct_v = np.array([[np.nan, 4.5622, np.nan, np.nan],
             [np.nan, 5.0177, np.nan, np.nan],
             [5.8538, np.nan, np.nan, np.nan],
             [6.2218, np.nan, np.nan, np.nan]], dtype=float)
+
+correct_v_0 = np.array([[0, 4.5622, 0, 0],
+            [0, 0, 5.0905, 0],
+            [0, 0, 4.3972, 0],
+            [0, 5.0177, 0, 0],
+            [5.8538, 0, 0, 0],
+            [6.2218, 0, 0, 0]], dtype=float)
+
 correct_w = np.array([[0.,1.,0.,0.],
             [0., 0., 1., 0.],
             [0., 0., 1., 0.],
@@ -41,6 +49,20 @@ def test_str_make_weights():
     assert np.array_equal(v, correct_v, equal_nan=True)
     assert np.max(np.abs(w-correct_w)) < 1e-5
 
+def test_str_make_weights_class():
+    temp_vals = np.array([['', 4.5622, '', ''],
+                ['', '', 5.0905, ''],
+                ['', '', 4.3972, ''],
+                ['', 5.0177, '', ''],
+                [5.8538, '', '', ''],
+                [6.2218, '', '', '']])
+
+    v, w = feat.make_weights(temp_vals, is_class=True)
+
+    assert np.array_equal(v, correct_v_0, equal_nan=True)
+    assert np.max(np.abs(w-correct_w)) < 1e-5
+
 if __name__ == '__main__':
     test_str_make_weights()
+    test_str_make_weights_class()
     test_nan_make_weights()


### PR DESCRIPTION
…assification nans changing to zeros 

I updated the make_weights function. Previously, only if `is_class = True` were the empty strings turned to nan's. Now, they are turned to nan's no matter what. If `is_class=True` then the nans are subsequently turned to zeros. The test_make_weights.py now passes.