### PR TITLE
Only run integrative tests if unit passes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   pytest-unit:
+    # TODO: Uncomment this when linter is in place
+    # needs: ruff
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,6 +52,7 @@ jobs:
       #   env:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   pytest-integrative-1:
+    needs: pytest-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -97,6 +100,7 @@ jobs:
       #   env:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   pytest-integrative-2:
+    needs: pytest-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -144,6 +148,7 @@ jobs:
       #   env:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   pytest-integrative-3:
+    needs: pytest-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -191,6 +196,7 @@ jobs:
       #   env:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   pytest-integrative-4:
+    needs: pytest-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This is a simple PR which does a couple things:
1. Only trigger integrative tests when unit tests are passing. 
2. Leaves a placeholder for when we have the linter merged. Then we can limit unit tests to only trigger when ruff is passing

This might help reduce some GitHub Actions usage