### PR TITLE
Pytest cicd

### DIFF
--- a/atomsci/ddm/test/integrative/compare_models/test_filesystem_perf_results.py
+++ b/atomsci/ddm/test/integrative/compare_models/test_filesystem_perf_results.py
@@ -8,6 +8,7 @@ import tarfile
 import json
 import glob
 import pandas as pd
+import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../delaney_Panel'))
 from test_delaney_panel import init, train_and_predict
@@ -248,6 +249,7 @@ def test_GraphConvModel_results():
 
     clean()
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_MPNN_results():
     if not llnl_utils.is_lc_system():
         assert True

--- a/atomsci/ddm/test/integrative/dc_models/test_dc_models.py
+++ b/atomsci/ddm/test/integrative/dc_models/test_dc_models.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import pytest
 
 from test_retrain_dc_models import *
@@ -6,6 +7,7 @@ from atomsci.ddm.utils import llnl_utils
 
 # Train and Predict
 # -----
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_AttentiveFPModel():
     if not llnl_utils.is_lc_system():
         assert True

--- a/atomsci/ddm/test/integrative/dc_models/test_retrain_dc_models.py
+++ b/atomsci/ddm/test/integrative/dc_models/test_retrain_dc_models.py
@@ -17,6 +17,7 @@ import atomsci.ddm.pipeline.parameter_parser as parse
 import atomsci.ddm.utils.model_retrain as mr
 import atomsci.ddm.utils.file_utils as futils
 from atomsci.ddm.utils import llnl_utils
+import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import integrative_utilities
@@ -212,6 +213,7 @@ def H1_init():
 
 # Train and Predict
 # -----
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_AttentiveFPModel():
     if not llnl_utils.is_lc_system():
         assert True
@@ -228,6 +230,7 @@ def test_reg_config_H1_fit_AttentiveFPModel():
     verify_saved_params(json_f, re_tar_f)
 
 # -----
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_GCNModel():
     if not llnl_utils.is_lc_system():
         assert True
@@ -244,6 +247,7 @@ def test_reg_config_H1_fit_GCNModel():
     verify_saved_params(json_f, re_tar_f)
 
 # -----
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_MPNNModel():
     if not llnl_utils.is_lc_system():
         assert True
@@ -259,6 +263,7 @@ def test_reg_config_H1_fit_MPNNModel():
 
     verify_saved_params(json_f, re_tar_f)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_GraphConvModel():
     if not llnl_utils.is_lc_system():
         assert True
@@ -274,6 +279,7 @@ def test_reg_config_H1_fit_GraphConvModel():
 
     verify_saved_params(json_f, re_tar_f)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_reg_config_H1_fit_PytorchMPNNModel():
     if not llnl_utils.is_lc_system():
         assert True

--- a/atomsci/ddm/test/integrative/delaney_Panel/test_delaney_panel.py
+++ b/atomsci/ddm/test/integrative/delaney_Panel/test_delaney_panel.py
@@ -12,6 +12,7 @@ import atomsci.ddm.pipeline.parameter_parser as parse
 import atomsci.ddm.utils.curate_data as curate_data
 import atomsci.ddm.utils.struct_utils as struct_utils
 from atomsci.ddm.utils import llnl_utils
+import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import integrative_utilities
@@ -327,26 +328,31 @@ def test_multi_reg_config_delaney_fit_NN_graphconv():
 # MOE doesn't seem to predict delaney very well
 # these are run using H1
 # -------
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test_reg_config_H1_fit_XGB_moe():
     H1_init()
     if llnl_utils.is_lc_system():
         train_and_predict('jsons/reg_config_H1_fit_XGB_moe.json', prefix='H1')
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test_reg_config_H1_fit_NN_moe():
     H1_init()
     if llnl_utils.is_lc_system():
         train_and_predict('jsons/reg_config_H1_fit_NN_moe.json', prefix='H1')
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test_reg_config_H1_double_fit_NN_moe():
     H1_double_init()
     if llnl_utils.is_lc_system():
         train_and_predict('jsons/reg_config_H1_double_fit_NN_moe.json', prefix='H1_double')
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test_multi_class_random_config_H1_fit_NN_moe():
     H1_init()
     if llnl_utils.is_lc_system():
         train_and_predict('jsons/multi_class_config_H1_fit_NN_moe.json', prefix='H1')
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test_class_config_H1_fit_NN_moe():
     H1_init()
     if llnl_utils.is_lc_system():

--- a/atomsci/ddm/test/integrative/early_stopping_tests/test_kfold_split.py
+++ b/atomsci/ddm/test/integrative/early_stopping_tests/test_kfold_split.py
@@ -1,10 +1,8 @@
 import copy
-import pdb
 import pandas as pd
 import numpy as np
 import json
 import os
-import sys
 
 import atomsci.ddm.pipeline.parameter_parser as parse
 import atomsci.ddm.pipeline.model_pipeline as mp
@@ -12,6 +10,8 @@ import atomsci.ddm.pipeline.predict_from_model as pfm
 from atomsci.ddm.utils import llnl_utils
 
 import sklearn.metrics as skmetrics
+
+import pytest
 
 def get_test_set(dskey, split_csv, id_col):
     """using model_metadata read dataset key and split uuid to split dataset into
@@ -55,7 +55,11 @@ def find_best_test_metric(model_metrics):
 
     return None
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_kfold():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'nn_ecfp_kfold.json')
 
@@ -66,7 +70,11 @@ def test_kfold():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_graphconv():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'nn_graph.json')
 
@@ -78,7 +86,11 @@ def test_graphconv():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_ecfp_nn():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'nn_ecfp.json')
 
@@ -90,7 +102,11 @@ def test_ecfp_nn():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_train_valid_test():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'nn_ecfp_random.json')
 
@@ -101,7 +117,11 @@ def test_train_valid_test():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_attentivefp():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'attentivefp_random.json')
 
@@ -112,7 +132,11 @@ def test_attentivefp():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_gcnmodel():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'gcnmodel_random.json')
 
@@ -123,7 +147,11 @@ def test_gcnmodel():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_graphconvmodel():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'GraphConvModel_random.json')
 
@@ -134,7 +162,11 @@ def test_graphconvmodel():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_mpnnmodel():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'MPNNModel_random.json')
 
@@ -145,7 +177,11 @@ def test_mpnnmodel():
 
     saved_model_identity(pparams)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_pytorchmpnnmodel():
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
     script_path = os.path.dirname(os.path.realpath(__file__))
     json_file = os.path.join(script_path, 'PytorchMPNNModel_random.json')
 
@@ -157,10 +193,6 @@ def test_pytorchmpnnmodel():
     saved_model_identity(pparams)
 
 def saved_model_identity(pparams):
-    if not llnl_utils.is_lc_system():
-        assert True
-        return
-        
     script_path = os.path.dirname(os.path.realpath(__file__))
     if not pparams.previously_split:
         split_uuid = split(pparams)

--- a/atomsci/ddm/test/integrative/hybrid/test_hybrid.py
+++ b/atomsci/ddm/test/integrative/hybrid/test_hybrid.py
@@ -11,6 +11,7 @@ from atomsci.ddm.pipeline import model_pipeline as mp
 from atomsci.ddm.utils import llnl_utils
 
 from sklearn.metrics import r2_score
+import pytest
 
 def clean():
     """Clean test files"""
@@ -20,16 +21,17 @@ def clean():
         if os.path.isfile("./output/"+f):
             os.remove("./output/"+f)
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
-
-    # Clean
-    # -----
-    clean()
 
     if not llnl_utils.is_lc_system():
         assert True
         return
+    
+    # Clean
+    # -----
+    clean()
 
     # Run HyperOpt
     # ------------

--- a/atomsci/ddm/test/integrative/hybrid/test_hybrid.py
+++ b/atomsci/ddm/test/integrative/hybrid/test_hybrid.py
@@ -24,7 +24,6 @@ def clean():
 @pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="MOE required")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
-
     if not llnl_utils.is_lc_system():
         assert True
         return

--- a/atomsci/ddm/test/integrative/maestro/test_maestro.py
+++ b/atomsci/ddm/test/integrative/maestro/test_maestro.py
@@ -119,7 +119,6 @@ def wait_to_finish(maestro_run_command, max_time=600):
 @pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Slurm required")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
-
     if not llnl_utils.is_lc_system():
         assert True
         return

--- a/atomsci/ddm/test/integrative/maestro/test_maestro.py
+++ b/atomsci/ddm/test/integrative/maestro/test_maestro.py
@@ -11,6 +11,8 @@ import atomsci.ddm.pipeline.compare_models as cm
 import glob
 from atomsci.ddm.utils import llnl_utils
 
+import pytest
+
 def clean():
     """Clean test files"""
     if "hyperparam_search" in os.listdir():
@@ -114,17 +116,18 @@ def wait_to_finish(maestro_run_command, max_time=600):
 
     return True
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Slurm required")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
-
-    # Clean
-    # -----
-    clean()
 
     if not llnl_utils.is_lc_system():
         assert True
         return
-        
+    
+    # Clean
+    # -----
+    clean()
+    
     # Run ECFP NN hyperparam search
     # ------------
     json_file = "nn_ecfp.json"

--- a/atomsci/ddm/test/integrative/shortlist_test/test_shortlist.py
+++ b/atomsci/ddm/test/integrative/shortlist_test/test_shortlist.py
@@ -10,6 +10,7 @@ import pandas as pd
 import tempfile
 import tarfile
 import json
+import pytest
 
 import atomsci.ddm.pipeline.parameter_parser as parse
 import atomsci.ddm.pipeline.compare_models as cm
@@ -167,29 +168,31 @@ def wait_to_finish(split_json, search_json, max_time=1200):
 
     return result_df
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Slurm required")
 def test():
     """Test full model pipeline: Split data, featurize data, fit model, get results"""
-
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
+    
     # Clean
     # -----
     clean()
-
+        
     # Init Data
     # -----
     init_data()
-
+        
     # Run shortlist hyperparam search
     # ------------
-    if llnl_utils.is_lc_system():
-        result_df = wait_to_finish("test_shortlist_split_config.json",
-            "test_shortlist_RF-NN-XG_hyperconfig.json", max_time=-1)
-        assert len(result_df) == 18 # Timed out
-    else:
-        assert True
-
+    result_df = wait_to_finish("test_shortlist_split_config.json",
+        "test_shortlist_RF-NN-XG_hyperconfig.json", max_time=-1)
+    assert len(result_df) == 18 # Timed out
+        
     # Clean
     # -----
     clean()
+
 
 def extract_split_uuid(tar_file):
     """Given a tar file, return split uuid used to train the model."""

--- a/atomsci/ddm/test/integrative/wenzel_NN/test_wenzel_NN.py
+++ b/atomsci/ddm/test/integrative/wenzel_NN/test_wenzel_NN.py
@@ -92,7 +92,6 @@ def download():
 @pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Requires access to Livermore dataset")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
-
     if not llnl_utils.is_lc_system():
         assert True
         return

--- a/atomsci/ddm/test/integrative/wenzel_NN/test_wenzel_NN.py
+++ b/atomsci/ddm/test/integrative/wenzel_NN/test_wenzel_NN.py
@@ -22,10 +22,6 @@ import integrative_utilities
 
 def clean():
     """Clean test files"""
-    if not llnl_utils.is_lc_system():
-        assert True
-        return
-
     for f in ['hlm_clearance_curated_predict.csv',
               'hlm_clearance_curated_external.csv',
               'hlm_clearance_curated_fit.csv',
@@ -93,10 +89,13 @@ def download():
 
     assert(os.path.isfile('ci8b00785_si_001.zip'))
 
-
 @pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Requires access to Livermore dataset")
 def test():
     """Test full model pipeline: Curate data, fit model, and predict property for new compounds"""
+
+    if not llnl_utils.is_lc_system():
+        assert True
+        return
 
     # Clean
     # -----

--- a/atomsci/ddm/test/run_llnl_int_tests.sh
+++ b/atomsci/ddm/test/run_llnl_int_tests.sh
@@ -2,20 +2,23 @@
 
 # set env
 export ENABLE_LIVERMORE=1
+BASEDIR=$(dirname $(realpath "$0"))
 
 # run integrative
-cd integrative
+cd $BASEDIR/integrative
 
-# walk the directory tree and run pytest
-for f in *; do
-    if [ -d "$f" ] ; then
-         # look for the directories that contain test*.py. if found, cd into and run pytest
-         file=($f/test_*.py)
-         if [[ -f "$file" ]]; then
-            cd ${f}
-            echo "Testing $f"
-            pytest -s -v -m "skipif"
-            cd ..
-        fi
-    fi
+TEST_FILES="$(grep -l 'skipif' ./*/test*.py)"
+
+# split to array
+array=(${TEST_FILES//$'\n'/ })
+
+# iterate
+for i in "${!array[@]}"
+do
+    file="${array[i]}"
+    parentdir="$(dirname "$file")"
+    cd $parentdir
+    echo "Testing $file"
+    pytest -ra -v -m "skipif"
+    cd ..
 done

--- a/atomsci/ddm/test/run_llnl_int_tests.sh
+++ b/atomsci/ddm/test/run_llnl_int_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# set env
+export ENABLE_LIVERMORE=1
+
+# run integrative
+cd integrative
+
+# walk the directory tree and run pytest
+for f in *; do
+    if [ -d "$f" ] ; then
+         # look for the directories that contain test*.py. if found, cd into and run pytest
+         file=($f/test_*.py)
+         if [[ -f "$file" ]]; then
+            cd ${f}
+            echo "Testing $f"
+            pytest -s -v -m "skipif"
+            cd ..
+        fi
+    fi
+done

--- a/atomsci/ddm/test/run_llnl_unit_tests.sh
+++ b/atomsci/ddm/test/run_llnl_unit_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# set env
+export ENABLE_LIVERMORE=1
+
+# run unit tests
+cd unit
+pytest -s -v -m "skipif" 

--- a/atomsci/ddm/test/run_llnl_unit_tests.sh
+++ b/atomsci/ddm/test/run_llnl_unit_tests.sh
@@ -2,7 +2,8 @@
 
 # set env
 export ENABLE_LIVERMORE=1
+BASEDIR=$(dirname $(realpath "$0"))
 
 # run unit tests
-cd unit
-pytest -s -v -m "skipif" 
+cd $BASEDIR/unit
+pytest -ra -v -m "skipif" 

--- a/atomsci/ddm/test/unit/test_LCTimerIterator.py
+++ b/atomsci/ddm/test/unit/test_LCTimerIterator.py
@@ -1,9 +1,11 @@
 import atomsci.ddm.pipeline.model_wrapper as mw
 import logging
-import time
+import os, time
 from argparse import Namespace
 from atomsci.ddm.utils import llnl_utils
+import pytest
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Slurm required")
 def test_LCTimerIterator_too_long():
     if not llnl_utils.is_lc_system():
         assert True
@@ -46,6 +48,7 @@ def test_LCTimerIterator_finishes_all_epochs():
 
     assert params.max_epochs == 10
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="Slurm required")
 def test_LCTimerKFoldIterator_too_long():
     if not llnl_utils.is_lc_system():
         assert True

--- a/atomsci/ddm/test/unit/test_num_trainable_params.py
+++ b/atomsci/ddm/test/unit/test_num_trainable_params.py
@@ -3,9 +3,12 @@ import os
 from atomsci.ddm.pipeline import compare_models as cm
 from atomsci.ddm.utils import llnl_utils
 
+import pytest
+
 def clean():
     pass
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test():
     if not llnl_utils.is_lc_system():
         assert True

--- a/atomsci/ddm/test/unit/test_prediction_order.py
+++ b/atomsci/ddm/test/unit/test_prediction_order.py
@@ -6,11 +6,15 @@ import numpy as np
 import sklearn.metrics as skm
 from atomsci.ddm.utils import llnl_utils
 
+import os
+import pytest
+
 """
 make sure that the various ways of making predictions return
 predictions in the same order as the input
 """
 
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_predict_from_model():
     """test that predict_from_model makes predictions in the same
     order as the input
@@ -45,7 +49,7 @@ def test_predict_from_model():
     print('accuracy score', score)
     assert score > 0.5
 
-
+@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="GPU required")
 def test_predict_full_dataset():
     """test that predict_full_dataset makes predictions in the same
     order as the input

--- a/pip/README.md
+++ b/pip/README.md
@@ -2,17 +2,19 @@
 
 AMPL provides different pip installation files for different environments and usages:
 
-* clients_requirements.txt : this is used if using model_tracker on LLNL LC environment.
+* ci_requirements.txt : pytest related requirements
+
+* clients_requirements.txt : used if using model_tracker on LLNL LC environment.
 
 * cpu_requirements.txt : minimal installation to run AMPL with CPU-only support.
 
 * cuda_requirements.txt : minimal installation to run AMPL with CUDA-enabled GPUs.
 
-* docker_requirements.txt : is used for AMPL docker image build.
+* docker_requirements.txt : used for AMPL docker image build.
 
-* mchip_requirements.txt : is used for macOS with M chip.
+* mchip_requirements.txt : used for macOS with M chip.
 
-* readthedocs_requirements.txt : is used for readthedocs build.
+* readthedocs_requirements.txt : used for readthedocs build.
 
 * rocm_requirements.txt : minimal installation to run AMPL with AMD ROCm GPUs. (**work in progress**)
 


### PR DESCRIPTION
- add markers `@pytest.mark.skipif(os.environ.get("ENABLE_LIVERMORE") is None, reason="...")` on the tests that can only run on LC due to some dependencies/reasons like:
  - GPU required
  - Slurm required
  - MOE required
 - Currently there are 39 tests
 - Provided scripts to run them on LC
   - run_llnl_unit_tests.sh
   - run_llnl_int_tests.sh