### PR TITLE
Only add gpus if platform is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ENV ?= dev
 
 # GPU / CPU
 PLATFORM ?= gpu
+ifeq ($(ARCH), gpu)
+    GPU_ARG = --gpus all
+endif
 
 # IMAGE REPOSITORY
 IMAGE_REPO ?= atomsci/atomsci-ampl
@@ -72,14 +75,14 @@ jupyter-notebook:
 	@echo "Starting Jupyter Notebook"
 ifdef host
 	docker run -p $(JUPYTER_PORT):$(JUPYTER_PORT) \
-	  --gpus all \
+	  $(GPU_ARG) \
 		--hostname $(host) \
 		--privileged \
 		-v $(shell pwd)/../$(WORK_DIR):/$(WORK_DIR) $(IMAGE_REPO):$(PLATFORM)-$(ENV) \
 		/bin/bash -l -c "jupyter-notebook --ip=0.0.0.0 --no-browser --allow-root --port=$(JUPYTER_PORT)"
 else
 	docker run -p $(JUPYTER_PORT):$(JUPYTER_PORT) \
-		--gpus all \
+		$(GPU_ARG) \
 		-v $(shell pwd)/../$(WORK_DIR):/$(WORK_DIR) $(IMAGE_REPO):$(PLATFORM)-$(ENV) \
 		/bin/bash -l -c "jupyter-notebook --ip=0.0.0.0 --no-browser --allow-root --port=$(JUPYTER_PORT)"
 endif


### PR DESCRIPTION
I was encountering the following error when running on a machine without a GPU:

```
docker run -p 8080:8080 \
  --gpus all \
        --hostname job-Gq8JzK80Zv77jJQFFzPBvY6Q.dnanexus.cloud \
        --privileged \
        -v /home/dnanexus/AMPL/../work/:/work/ kartstig/ampl:cpu-pfda \
        /bin/bash -l -c "jupyter-notebook --ip=0.0.0.0 --no-browser --allow-root --port=8080"
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: initialization error: driver error: failed to process request: unknown.
ERRO[0001] error waiting for container:                 
make: *** [Makefile:73: jupyter-notebook] Error 125
```