### PR TITLE
create a mchip_dev_requirements to fix the issue with 'matplotcheck' …

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -23,7 +23,7 @@ RUN pip install -U pip && \
     --trusted-host download.pytorch.org \
     -r ./pip/mchip_requirements.txt
 
-COPY ./pip/dev_requirements.txt ./pip/dev_requirements.txt
+COPY ./pip/mchip_dev_requirements.txt ./pip/mchip_dev_requirements.txt
 RUN pip install -U pip && \
     pip install --no-cache-dir \
     --trusted-host pypi.python.org \
@@ -31,7 +31,7 @@ RUN pip install -U pip && \
     --trusted-host pypi.org \
     --trusted-host data.dgl.ai \
     --trusted-host download.pytorch.org \
-    -r ./pip/dev_requirements.txt
+    -r ./pip/mchip_dev_requirements.txt
 
 COPY setup.py .
 COPY VERSION .

--- a/pip/mchip_dev_requirements.txt
+++ b/pip/mchip_dev_requirements.txt
@@ -1,0 +1,14 @@
+bokeh
+ipykernel
+jupyter
+jupyterlab
+maestrowf
+matplotlib
+matplotlib-venn
+pytest
+pytest-cov
+pytest-mock
+pytest-xdist
+ruff
+seaborn>=0.13.0
+umap-learn


### PR DESCRIPTION
…install issue on arm chip

- Ran the test manually and ran fine. 

```
 export PLATFORM=arm
 export ENV=prod
 export ARCH="linux/arm64"
 make build-docker
```
Will test the image on mchip environment and push to the docker repo.